### PR TITLE
Ignore YAML frontmatter for Setext headings

### DIFF
--- a/src/jdocmunch_mcp/parser/markdown_parser.py
+++ b/src/jdocmunch_mcp/parser/markdown_parser.py
@@ -70,6 +70,16 @@ _SETEXT_H2_RE = re.compile(r"^-+\s*$")
 _FENCE_OPEN_RE = re.compile(r"^(`{3,}|~{3,})\s*[\w.+-]*\s*$")
 
 
+def _frontmatter_end_line(lines: list) -> int | None:
+    """Return the closing line index for top-of-file YAML frontmatter."""
+    if not lines or lines[0].strip() != "---":
+        return None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return i
+    return None
+
+
 def parse_markdown(content: str, doc_path: str, repo: str) -> list:
     """Parse a markdown file into a list of Section objects.
 
@@ -155,10 +165,20 @@ def parse_markdown(content: str, doc_path: str, repo: str) -> list:
     fence_lang: str = ""
     fence_body_byte_start: int = 0
     fence_body_lines: list = []
+    frontmatter_end_line = _frontmatter_end_line(lines)
 
     for i, line in enumerate(lines):
         line_bytes = len(line.encode("utf-8"))
         line_stripped = line.rstrip("\n").rstrip("\r")
+
+        if frontmatter_end_line is not None and i <= frontmatter_end_line:
+            current_lines.append(line)
+            byte_cursor += line_bytes
+            # YAML metadata is not Markdown body text, so it must not seed
+            # Setext heading detection for the closing delimiter.
+            prev_line = ""
+            prev_byte_start = byte_cursor
+            continue
 
         # --- Fence state machine (B2 + v1.17.0 capture) ---
         if in_fence:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -122,6 +122,30 @@ class TestMarkdownParser:
         titles = [s.title for s in sections]
         assert "Setext heading style" in titles or any("setext" in t.lower() for t in titles)
 
+    def test_yaml_frontmatter_is_not_setext_heading(self):
+        content = (
+            "---\n"
+            "name: example\n"
+            "description: This metadata line is followed by the closing delimiter.\n"
+            "---\n"
+            "\n"
+            "# Title\n"
+            "\n"
+            "Body.\n"
+        )
+        sections = parse_markdown(content, "doc.md", "repo")
+        titles = [s.title for s in sections]
+
+        assert "Title" in titles
+        assert not any(title.startswith("description:") for title in titles)
+
+    def test_leading_horizontal_rule_without_closing_frontmatter_still_parses(self):
+        content = "---\n\n# Title\n\nBody.\n"
+        sections = parse_markdown(content, "doc.md", "repo")
+        titles = [s.title for s in sections]
+
+        assert "Title" in titles
+
     def test_slug_collision_in_doc(self):
         content = "## Install\n\nFirst.\n\n## Install\n\nSecond.\n"
         sections = parse_markdown(content, "doc.md", "repo")


### PR DESCRIPTION
### Summary

- Treat top-of-file YAML frontmatter as metadata during Markdown heading detection.
- Prevent a closing `---` delimiter from turning the preceding metadata line into a Setext H2 section.
- Add regression coverage for frontmatter and for a leading horizontal rule without a closing frontmatter delimiter.

### Why

Plain Markdown files with YAML frontmatter can currently produce false sections. For example, this frontmatter:

```yaml
---
name: example
description: This metadata line is followed by the closing delimiter.
---
```

can cause `description: ...` to be indexed as a Setext H2 because the next line is `---`. That also makes freshness checks report stale pseudo-sections after reindexing.

### Testing

All tests pass with project's dev dependencies:

- `uv run pytest tests/ -q` - 1119 passed