### PR TITLE
Add sentence-transformers as an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,25 @@ MiniMax, or GLM-5, include the optional dependency in the launcher command:
 }
 ```
 
+For fully offline embeddings (no API key required), include the
+`sentence-transformers` optional dependency. The default model
+(`all-MiniLM-L6-v2`, ~80 MB) downloads on first use into
+`~/.cache/huggingface/`:
+
+```json
+{
+  "mcpServers": {
+    "jdocmunch": {
+      "command": "uvx",
+      "args": ["--with", "sentence-transformers", "jdocmunch-mcp"],
+      "env": {
+        "JDOCMUNCH_EMBEDDING_PROVIDER": "sentence-transformers"
+      }
+    }
+  }
+}
+```
+
 After saving the config, **restart Claude Desktop / Claude Code**.
 
 ### Claude Code hooks (recommended)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ openai = ["openai>=1.0.0"]
 minimax = ["openai>=1.0.0"]
 zhipu = ["openai>=1.0.0"]
 semantic = ["google-generativeai>=0.8.0"]
+sentence-transformers = ["sentence-transformers>=5.4.1"]
 
 [project.scripts]
 jdocmunch-mcp = "jdocmunch_mcp.server:main"


### PR DESCRIPTION
## Summary

Adds `sentence-transformers` to `[project.optional-dependencies]` so users who want fully offline embeddings can install via the established `uvx --with <extra>` pattern that the README already documents for OpenAI / MiniMax / GLM.

The runtime already supports it — `provider.py` auto-detects the package, `JDOCMUNCH_EMBEDDING_PROVIDER` accepts `sentence-transformers` as a valid value, and `JDOCMUNCH_ST_MODEL` configures the model. Only the install path was missing from the optional-dependencies surface, leaving downstream users to either manually `pip install sentence-transformers` alongside the package or fork `pyproject.toml`. This PR closes that gap with a one-line addition that follows the existing per-provider extras convention.

The change is additive — no existing behavior is altered, no existing tests need updates.

## Changes

- `pyproject.toml`: one line — `sentence-transformers = ["sentence-transformers>=5.4.1"]` appended to `[project.optional-dependencies]`
- `README.md`: 19-line example block under the existing "include the optional dependency" section showing the offline-embedding install via `uvx --with sentence-transformers jdocmunch-mcp`

## Test plan

- [ ] `pytest tests/ -q` continues to pass (no runtime change)
- [ ] `uvx --with sentence-transformers jdocmunch-mcp` resolves and starts the server
- [ ] First `index_local` call writes embeddings (`_meta.search_mode=hybrid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)