### PR TITLE
index identity: expose certified repo@sha handles for citeable doc snapshots

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -65,7 +65,7 @@ Deletes both the index JSON and the raw content cache directory.
 
 #### `list_repos` — List indexed documentation sets
 
-No input required. Returns all indexed repositories with section counts, document counts, and document type breakdown.
+No input required. Returns all indexed repositories with section counts, document counts, document type breakdown, and commit metadata when available. Clean Git-backed indexes include `repo_at_sha`, an immutable handle in the form `owner/repo@40hexsha`.
 
 #### `get_toc` — Flat table of contents
 
@@ -113,7 +113,7 @@ Returns the heading hierarchy for a single file without content. Lighter than `g
 }
 ```
 
-Weighted scoring across title, summary, tags, and content. Returns summaries only — use `get_section` for full content. `doc_path` is optional; omit to search all documents.
+Weighted scoring across title, summary, tags, and content. Returns summaries only — use `get_section` for full content. `doc_path` is optional; omit to search all documents. `repo` accepts the normal `owner/repo` identifier or a strict `owner/repo@40hexsha` handle; the latter resolves only when the stored index is clean and matches that exact commit.
 
 ---
 
@@ -198,10 +198,14 @@ class DocIndex:
     doc_paths: list        # Sorted list of indexed document paths
     doc_types: dict        # {".md": 12, ".txt": 3}
     sections: list         # Serialized Section dicts (metadata only — no content field)
-    index_version: int     # Schema version (current: 2); mismatch triggers full re-index
+    index_version: int     # Schema version (current: 3); mismatch triggers full re-index
     file_hashes: dict      # {doc_path: SHA-256} for incremental change detection
-    head_sha: str          # HEAD commit SHA (GitHub repos); enables O(1) no-change detection
+    head_sha: str          # HEAD commit SHA when known (GitHub or local Git indexes)
+    source_dirty: bool     # True when cached content is not certified clean at head_sha
+    source_root: str       # Absolute source folder for local indexes, if known
 ```
+
+`repo_at_sha` is derived, not stored: it is emitted only when `head_sha` is a 40-hex commit SHA and `source_dirty` is false. Surgical `index_file` updates never clear a dirty, moved-HEAD, or no-longer-Git-backed local index; run `index_local` to recertify the full corpus.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -202,10 +202,14 @@ class DocIndex:
     file_hashes: dict      # {doc_path: SHA-256} for incremental change detection
     head_sha: str          # HEAD commit SHA when known (GitHub or local Git indexes)
     source_dirty: bool     # True when cached content is not certified clean at head_sha
+    sha_certified: bool    # True when the corpus was built under strict repo@sha rules
     source_root: str       # Absolute source folder for local indexes, if known
 ```
 
-`repo_at_sha` is derived, not stored: it is emitted only when `head_sha` is a 40-hex commit SHA and `source_dirty` is false. Surgical `index_file` updates never clear a dirty, moved-HEAD, or no-longer-Git-backed local index; run `index_local` to recertify the full corpus.
+`DocStore` persists each `DocIndex` as JSON plus cached raw document files.
+`repo_at_sha` is derived, not stored: it is emitted only when `head_sha` is a 40-hex commit SHA, `source_dirty` is false, and `sha_certified` is true. Surgical `index_file` updates never certify a legacy, dirty, moved-HEAD, untracked-path, or no-longer-Git-backed local index; run `index_local` to recertify the full corpus.
+
+For local Git indexes, "clean" means the *indexed corpus* is reproducible at `head_sha`, not that the source folder is pristine. `source_dirty` is set when tracked content within the indexed scope differs from HEAD, when HEAD moves mid-index, or when any indexed path is not tracked by Git — including a gitignored file indexed explicitly via `paths=[...]`, which `git status` cannot see and which is caught by a separate `git ls-files` tracked-ness check. Untracked files that are not part of the index — unsupported extensions, build artifacts, scratch files — do not affect certification. Git state is probed with short-lived `git` subprocesses bounded by `JDOCMUNCH_GIT_TIMEOUT` (seconds, default 10; set to a value `<= 0` to disable the ceiling); a timed-out or otherwise failed probe is treated as dirty so an immutable handle is never emitted for an unknown state.
 
 ---
 
@@ -324,4 +328,5 @@ All errors return:
 | `JDOCMUNCH_OPENAI_COMPAT_BATCH_SIZE` | Batch size for `openai-compatible` embeddings (default: `32`)      | No       |
 | `JDOCMUNCH_ST_MODEL`              | sentence-transformers model name (default: `all-MiniLM-L6-v2`)      | No       |
 | `DOC_INDEX_PATH`                  | Custom storage path (default: `~/.doc-index/`)                       | No       |
+| `JDOCMUNCH_GIT_TIMEOUT`           | Per-call `git` subprocess ceiling in seconds for local repo@sha probing (default: `10`; `<= 0` disables) | No |
 | `JDOCMUNCH_SHARE_SAVINGS`         | Set to `0` to disable anonymous token savings reporting              | No       |

--- a/src/jdocmunch_mcp/cli/hooks.py
+++ b/src/jdocmunch_mcp/cli/hooks.py
@@ -163,7 +163,7 @@ def _build_snapshot() -> str:
     lines = ["## jDocMunch Session Snapshot", ""]
     lines.append(f"Indexed doc repos: {len(repos)}")
     for r in repos:
-        name = r.get("name", r.get("repo", "?"))
+        name = r.get("repo_at_sha", r.get("name", r.get("repo", "?")))
         sections = r.get("section_count", r.get("sections", "?"))
         docs = r.get("doc_count", r.get("documents", "?"))
         source = r.get("source_root", r.get("source", ""))

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -472,7 +472,10 @@ class DocStore:
 
     def load_index(self, owner: str, name: str) -> Optional[DocIndex]:
         """Load index from storage, using an in-memory cache keyed by (path, mtime)."""
-        index_path = self._index_path(owner, name)
+        try:
+            index_path = self._index_path(owner, name)
+        except ValueError:
+            return None
         if not index_path.exists():
             return None
 
@@ -748,8 +751,11 @@ class DocStore:
 
     def delete_index(self, owner: str, name: str) -> bool:
         """Delete an index and its raw content cache."""
-        index_path = self._index_path(owner, name)
-        content_dir = self._content_dir(owner, name)
+        try:
+            index_path = self._index_path(owner, name)
+            content_dir = self._content_dir(owner, name)
+        except ValueError:
+            return False
 
         deleted = False
         if index_path.exists():
@@ -826,6 +832,6 @@ class DocStore:
         if index and indexed_sha == wanted_sha and not index.source_dirty:
             return owner, name
 
-        # Preserve the old tuple-only contract. Callers will load this safe,
-        # non-existent repo and return their normal "Repo not found" shape.
-        return "local", "__repo_at_sha_not_found__"
+        # Preserve the old tuple-only contract. The invalid name is intentionally
+        # uncreatable as an index, so a miss cannot collide with a real repo.
+        return "local", "__repo_at_sha_not_found__:sha_mismatch"

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -55,10 +55,15 @@ def normalize_commit_sha(value: Optional[str]) -> Optional[str]:
     return value.lower()
 
 
-def format_repo_at_sha(repo: str, head_sha: Optional[str], source_dirty: bool = False) -> Optional[str]:
+def format_repo_at_sha(
+    repo: str,
+    head_sha: Optional[str],
+    source_dirty: bool = False,
+    sha_certified: bool = False,
+) -> Optional[str]:
     """Return the immutable repo@sha handle when this index is commit-clean."""
     sha = normalize_commit_sha(head_sha)
-    if not sha or source_dirty:
+    if not sha or source_dirty or not sha_certified:
         return None
     return f"{repo}@{sha}"
 
@@ -85,6 +90,7 @@ class DocIndex:
     file_hashes: dict = field(default_factory=dict)
     head_sha: Optional[str] = None
     source_dirty: bool = False
+    sha_certified: bool = False
     # v1.12.0: BM25 corpus stats. Empty dict for legacy indices — score_section
     # gracefully degrades when stats are missing.
     bm25_stats: dict = field(default_factory=dict)
@@ -107,7 +113,12 @@ class DocIndex:
 
     @property
     def repo_at_sha(self) -> Optional[str]:
-        return format_repo_at_sha(self.repo, self.head_sha, self.source_dirty)
+        return format_repo_at_sha(
+            self.repo,
+            self.head_sha,
+            self.source_dirty,
+            self.sha_certified,
+        )
 
     def _ensure_content(self, sec: dict) -> str:
         """Return section content, loading from disk lazily if missing.
@@ -419,6 +430,7 @@ class DocStore:
         file_hashes: Optional[dict] = None,
         head_sha: Optional[str] = None,
         source_dirty: bool = False,
+        sha_certified: bool = False,
         source_root: str = "",
     ) -> "DocIndex":
         """Save index and raw files to storage atomically."""
@@ -444,6 +456,7 @@ class DocStore:
             file_hashes=file_hashes,
             head_sha=head_sha,
             source_dirty=source_dirty,
+            sha_certified=sha_certified,
             bm25_stats=bm25_stats,
             source_root=source_root or "",
         )
@@ -505,6 +518,7 @@ class DocStore:
             file_hashes=data.get("file_hashes", {}),
             head_sha=data.get("head_sha"),
             source_dirty=bool(data.get("source_dirty", False)),
+            sha_certified=bool(data.get("sha_certified", False)),
             bm25_stats=data.get("bm25_stats", {}),
             source_root=data.get("source_root", ""),
         )
@@ -572,6 +586,7 @@ class DocStore:
         doc_types: dict,
         head_sha=_UNSET,
         source_dirty=_UNSET,
+        sha_certified=_UNSET,
         source_root=_UNSET,
     ) -> Optional["DocIndex"]:
         """Incrementally update an existing index.
@@ -658,6 +673,7 @@ class DocStore:
             file_hashes=file_hashes,
             head_sha=index.head_sha if head_sha is _UNSET else head_sha,
             source_dirty=index.source_dirty if source_dirty is _UNSET else bool(source_dirty),
+            sha_certified=index.sha_certified if sha_certified is _UNSET else bool(sha_certified),
             bm25_stats=bm25_stats,
             source_root=index.source_root if source_root is _UNSET else (source_root or ""),
         )
@@ -736,10 +752,12 @@ class DocStore:
                 }
                 sha = normalize_commit_sha(data.get("head_sha"))
                 source_dirty = bool(data.get("source_dirty", False))
+                sha_certified = bool(data.get("sha_certified", False))
                 if sha:
                     row["head_sha"] = sha
                 row["source_dirty"] = source_dirty
-                repo_at_sha = format_repo_at_sha(data["repo"], sha, source_dirty)
+                row["sha_certified"] = sha_certified
+                repo_at_sha = format_repo_at_sha(data["repo"], sha, source_dirty, sha_certified)
                 if repo_at_sha:
                     row["repo_at_sha"] = repo_at_sha
                 if data.get("source_root"):
@@ -783,6 +801,8 @@ class DocStore:
             d["head_sha"] = index.head_sha
         if index.source_dirty:
             d["source_dirty"] = True
+        if index.sha_certified:
+            d["sha_certified"] = True
         if index.bm25_stats:
             d["bm25_stats"] = index.bm25_stats
         if getattr(index, "source_root", ""):
@@ -829,7 +849,7 @@ class DocStore:
 
         index = self.load_index(owner, name)
         indexed_sha = normalize_commit_sha(index.head_sha if index else None)
-        if index and indexed_sha == wanted_sha and not index.source_dirty:
+        if index and indexed_sha == wanted_sha and not index.source_dirty and index.sha_certified:
             return owner, name
 
         # Preserve the old tuple-only contract. The invalid name is intentionally

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import os
+import re
 import shutil
 from collections import OrderedDict
 from dataclasses import dataclass, field
@@ -14,6 +15,8 @@ from ..parser.sections import Section
 from ..embeddings import embed_query, cosine_similarity
 
 INDEX_VERSION = 3
+COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_UNSET = object()
 
 # Module-level LRU cache: {(str(index_path), mtime_ns): DocIndex}
 # Keyed by path + mtime so the entry auto-invalidates whenever the file changes.
@@ -42,6 +45,24 @@ def _file_hash(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
+def normalize_commit_sha(value: Optional[str]) -> Optional[str]:
+    """Return a normalized 40-hex commit SHA, or None for non-commit refs."""
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not COMMIT_SHA_RE.fullmatch(value):
+        return None
+    return value.lower()
+
+
+def format_repo_at_sha(repo: str, head_sha: Optional[str], source_dirty: bool = False) -> Optional[str]:
+    """Return the immutable repo@sha handle when this index is commit-clean."""
+    sha = normalize_commit_sha(head_sha)
+    if not sha or source_dirty:
+        return None
+    return f"{repo}@{sha}"
+
+
 def _evict_index_cache(index_path: Path) -> None:
     """Remove all cache entries for a given index path (any mtime)."""
     path_str = str(index_path)
@@ -63,6 +84,7 @@ class DocIndex:
     index_version: int = INDEX_VERSION
     file_hashes: dict = field(default_factory=dict)
     head_sha: Optional[str] = None
+    source_dirty: bool = False
     # v1.12.0: BM25 corpus stats. Empty dict for legacy indices — score_section
     # gracefully degrades when stats are missing.
     bm25_stats: dict = field(default_factory=dict)
@@ -82,6 +104,10 @@ class DocIndex:
         self._content_loader = None  # type: ignore[var-annotated]
         # Per-search content cache: section_id -> str. Cleared between searches.
         self._content_cache: dict = {}
+
+    @property
+    def repo_at_sha(self) -> Optional[str]:
+        return format_repo_at_sha(self.repo, self.head_sha, self.source_dirty)
 
     def _ensure_content(self, sec: dict) -> str:
         """Return section content, loading from disk lazily if missing.
@@ -392,6 +418,7 @@ class DocStore:
         doc_types: dict,        # {".md": N}
         file_hashes: Optional[dict] = None,
         head_sha: Optional[str] = None,
+        source_dirty: bool = False,
         source_root: str = "",
     ) -> "DocIndex":
         """Save index and raw files to storage atomically."""
@@ -416,6 +443,7 @@ class DocStore:
             index_version=INDEX_VERSION,
             file_hashes=file_hashes,
             head_sha=head_sha,
+            source_dirty=source_dirty,
             bm25_stats=bm25_stats,
             source_root=source_root or "",
         )
@@ -473,6 +501,7 @@ class DocStore:
             index_version=stored_version,
             file_hashes=data.get("file_hashes", {}),
             head_sha=data.get("head_sha"),
+            source_dirty=bool(data.get("source_dirty", False)),
             bm25_stats=data.get("bm25_stats", {}),
             source_root=data.get("source_root", ""),
         )
@@ -538,7 +567,9 @@ class DocStore:
         new_sections: list,     # list[Section]
         raw_files: dict,        # {doc_path: content} for changed + new files only
         doc_types: dict,
-        head_sha: Optional[str] = None,
+        head_sha=_UNSET,
+        source_dirty=_UNSET,
+        source_root=_UNSET,
     ) -> Optional["DocIndex"]:
         """Incrementally update an existing index.
 
@@ -622,8 +653,10 @@ class DocStore:
             sections=all_section_dicts,
             index_version=INDEX_VERSION,
             file_hashes=file_hashes,
-            head_sha=head_sha,
+            head_sha=index.head_sha if head_sha is _UNSET else head_sha,
+            source_dirty=index.source_dirty if source_dirty is _UNSET else bool(source_dirty),
             bm25_stats=bm25_stats,
+            source_root=index.source_root if source_root is _UNSET else (source_root or ""),
         )
 
         # Save atomically
@@ -690,14 +723,25 @@ class DocStore:
             try:
                 with open(index_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
-                repos.append({
+                row = {
                     "repo": data["repo"],
                     "indexed_at": data["indexed_at"],
                     "section_count": len(data["sections"]),
                     "doc_count": len(data["doc_paths"]),
                     "doc_types": data["doc_types"],
                     "index_version": data.get("index_version", 1),
-                })
+                }
+                sha = normalize_commit_sha(data.get("head_sha"))
+                source_dirty = bool(data.get("source_dirty", False))
+                if sha:
+                    row["head_sha"] = sha
+                row["source_dirty"] = source_dirty
+                repo_at_sha = format_repo_at_sha(data["repo"], sha, source_dirty)
+                if repo_at_sha:
+                    row["repo_at_sha"] = repo_at_sha
+                if data.get("source_root"):
+                    row["source_root"] = data["source_root"]
+                repos.append(row)
             except Exception:
                 continue
         return repos
@@ -731,13 +775,23 @@ class DocStore:
         }
         if index.head_sha:
             d["head_sha"] = index.head_sha
+        if index.source_dirty:
+            d["source_dirty"] = True
         if index.bm25_stats:
             d["bm25_stats"] = index.bm25_stats
         if getattr(index, "source_root", ""):
             d["source_root"] = index.source_root
         return d
 
-    def _resolve_repo(self, repo: str) -> tuple:
+    def _split_repo_at_sha(self, repo: str) -> tuple[str, Optional[str]]:
+        if not isinstance(repo, str):
+            return str(repo), None
+        base, sep, suffix = repo.rpartition("@")
+        if sep and normalize_commit_sha(suffix):
+            return base, normalize_commit_sha(suffix)
+        return repo, None
+
+    def _resolve_repo_base(self, repo: str) -> tuple:
         """Resolve a 'owner/name' or bare 'name' string.
 
         Returns (owner, name). For bare names without a slash, tries to find
@@ -759,3 +813,19 @@ class DocStore:
 
         # Default to local/name
         return "local", repo
+
+    def _resolve_repo(self, repo: str) -> tuple:
+        """Resolve repo identifiers, including strict repo@40hex aliases."""
+        base_repo, wanted_sha = self._split_repo_at_sha(repo)
+        owner, name = self._resolve_repo_base(base_repo)
+        if not wanted_sha:
+            return owner, name
+
+        index = self.load_index(owner, name)
+        indexed_sha = normalize_commit_sha(index.head_sha if index else None)
+        if index and indexed_sha == wanted_sha and not index.source_dirty:
+            return owner, name
+
+        # Preserve the old tuple-only contract. Callers will load this safe,
+        # non-existent repo and return their normal "Repo not found" shape.
+        return "local", "__repo_at_sha_not_found__"

--- a/src/jdocmunch_mcp/tools/_git.py
+++ b/src/jdocmunch_mcp/tools/_git.py
@@ -1,0 +1,70 @@
+"""Small Git helpers for local indexing metadata."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from ..storage.doc_store import normalize_commit_sha
+
+
+def _git(cwd: Path, args: list[str]) -> tuple[bool, str]:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=2,
+            check=True,
+        )
+    except Exception:
+        return False, ""
+    return True, proc.stdout.strip()
+
+
+def local_git_state(folder_path: Path, scope_path: Optional[Path] = None) -> tuple[Optional[str], bool]:
+    """Return (HEAD sha, dirty) for a local Git worktree.
+
+    Non-Git folders return ``(None, False)``. Once a worktree is detected,
+    failure to prove clean status is treated as dirty so callers never emit an
+    immutable repo@sha handle for an unknown state.
+    """
+    folder_path = folder_path.resolve()
+    ok, inside = _git(folder_path, ["rev-parse", "--is-inside-work-tree"])
+    if not ok or inside != "true":
+        return None, False
+
+    ok, head = _git(folder_path, ["rev-parse", "HEAD"])
+    head_sha = normalize_commit_sha(head)
+    if not ok or not head_sha:
+        return None, False
+
+    ok, root = _git(folder_path, ["rev-parse", "--show-toplevel"])
+    git_root = Path(root).resolve() if ok and root else folder_path
+
+    status_args = ["status", "--porcelain"]
+    if scope_path is not None:
+        try:
+            rel = scope_path.resolve().relative_to(git_root).as_posix()
+        except ValueError:
+            rel = scope_path.resolve().as_posix()
+        status_args.extend(["--", rel or "."])
+
+    ok, status = _git(git_root, status_args)
+    if not ok:
+        return head_sha, True
+    return head_sha, bool(status)
+
+
+def stable_local_git_state(
+    before: tuple[Optional[str], bool],
+    after: tuple[Optional[str], bool],
+) -> tuple[Optional[str], bool]:
+    """Combine pre/post read Git state; SHA movement makes the index dirty."""
+    before_sha, before_dirty = before
+    after_sha, after_dirty = after
+    moved = before_sha != after_sha and bool(before_sha or after_sha)
+    return after_sha or before_sha, bool(before_dirty or after_dirty or moved)

--- a/src/jdocmunch_mcp/tools/_git.py
+++ b/src/jdocmunch_mcp/tools/_git.py
@@ -2,11 +2,31 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
 from ..storage.doc_store import normalize_commit_sha
+
+DEFAULT_GIT_TIMEOUT = 10.0
+
+
+def _git_timeout() -> Optional[float]:
+    """Resolve the per-call git subprocess ceiling (seconds).
+
+    Bounded by default so a blocked git (index.lock contention, credential
+    prompt, LFS smudge) can never hang the synchronous tool path. Override with
+    ``JDOCMUNCH_GIT_TIMEOUT``; a value <= 0 disables the ceiling entirely.
+    """
+    raw = os.environ.get("JDOCMUNCH_GIT_TIMEOUT", "").strip()
+    if not raw:
+        return DEFAULT_GIT_TIMEOUT
+    try:
+        val = float(raw)
+    except ValueError:
+        return DEFAULT_GIT_TIMEOUT
+    return val if val > 0 else None
 
 
 def _git(cwd: Path, args: list[str]) -> tuple[bool, str]:
@@ -17,7 +37,7 @@ def _git(cwd: Path, args: list[str]) -> tuple[bool, str]:
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
-            timeout=2,
+            timeout=_git_timeout(),
             check=True,
         )
     except Exception:
@@ -25,27 +45,62 @@ def _git(cwd: Path, args: list[str]) -> tuple[bool, str]:
     return True, proc.stdout.strip()
 
 
+def _git_bytes(cwd: Path, args: list[str]) -> tuple[bool, bytes]:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=_git_timeout(),
+            check=True,
+        )
+    except Exception:
+        return False, b""
+    return True, proc.stdout
+
+
+def _git_root(folder_path: Path) -> Optional[Path]:
+    ok, inside = _git(folder_path, ["rev-parse", "--is-inside-work-tree"])
+    if not ok or inside != "true":
+        return None
+    ok, root = _git(folder_path, ["rev-parse", "--show-toplevel"])
+    return Path(root).resolve() if ok and root else None
+
+
+def local_git_head(folder_path: Path) -> Optional[str]:
+    """Return the current HEAD SHA for a local Git worktree, if available."""
+    folder_path = folder_path.resolve()
+    if _git_root(folder_path) is None:
+        return None
+    ok, head = _git(folder_path, ["rev-parse", "HEAD"])
+    return normalize_commit_sha(head) if ok else None
+
+
 def local_git_state(folder_path: Path, scope_path: Optional[Path] = None) -> tuple[Optional[str], bool]:
     """Return (HEAD sha, dirty) for a local Git worktree.
+
+    "Dirty" means tracked content in scope differs from HEAD. Untracked files
+    are deliberately ignored (``--untracked-files=no``): they do not affect
+    whether the *indexed corpus* is reproducible at HEAD, and that corpus is
+    independently proven fully tracked by ``local_git_paths_tracked``. The
+    explicit ``no`` mode also overrides any ``status.showUntrackedFiles`` repo
+    config so the result is deterministic.
 
     Non-Git folders return ``(None, False)``. Once a worktree is detected,
     failure to prove clean status is treated as dirty so callers never emit an
     immutable repo@sha handle for an unknown state.
     """
     folder_path = folder_path.resolve()
-    ok, inside = _git(folder_path, ["rev-parse", "--is-inside-work-tree"])
-    if not ok or inside != "true":
+    git_root = _git_root(folder_path)
+    if git_root is None:
         return None, False
 
-    ok, head = _git(folder_path, ["rev-parse", "HEAD"])
-    head_sha = normalize_commit_sha(head)
-    if not ok or not head_sha:
+    head_sha = local_git_head(folder_path)
+    if not head_sha:
         return None, False
 
-    ok, root = _git(folder_path, ["rev-parse", "--show-toplevel"])
-    git_root = Path(root).resolve() if ok and root else folder_path
-
-    status_args = ["status", "--porcelain"]
+    status_args = ["status", "--porcelain", "--untracked-files=no"]
     if scope_path is not None:
         try:
             rel = scope_path.resolve().relative_to(git_root).as_posix()
@@ -57,6 +112,68 @@ def local_git_state(folder_path: Path, scope_path: Optional[Path] = None) -> tup
     if not ok:
         return head_sha, True
     return head_sha, bool(status)
+
+
+def _indexed_git_paths(folder_path: Path, indexed_paths: Iterable[str]) -> tuple[Optional[Path], Optional[set[str]]]:
+    folder_path = folder_path.resolve()
+    git_root = _git_root(folder_path)
+    if git_root is None:
+        return None, None
+
+    wanted: set[str] = set()
+    for rel_path in indexed_paths:
+        if not isinstance(rel_path, str) or not rel_path:
+            return git_root, None
+        try:
+            git_rel = (folder_path / rel_path).resolve().relative_to(git_root).as_posix()
+        except ValueError:
+            return git_root, None
+        wanted.add(git_rel)
+    return git_root, wanted
+
+
+def local_git_paths_dirty(folder_path: Path, indexed_paths: Iterable[str]) -> bool:
+    """Return True when tracked indexed paths differ from HEAD."""
+    git_root, wanted = _indexed_git_paths(folder_path, indexed_paths)
+    if git_root is None:
+        return False
+    if wanted is None:
+        return True
+    if not wanted:
+        return False
+
+    ordered = sorted(wanted)
+    chunk_size = 200
+    for i in range(0, len(ordered), chunk_size):
+        ok, status = _git(
+            git_root,
+            ["status", "--porcelain", "--untracked-files=no", "--", *ordered[i:i + chunk_size]],
+        )
+        if not ok or status:
+            return True
+    return False
+
+
+def local_git_paths_tracked(folder_path: Path, indexed_paths: Iterable[str]) -> bool:
+    """Return True when every indexed path is tracked by Git."""
+    git_root, wanted = _indexed_git_paths(folder_path, indexed_paths)
+    if git_root is None or wanted is None:
+        return False
+
+    if not wanted:
+        return True
+
+    tracked: set[str] = set()
+    ordered = sorted(wanted)
+    chunk_size = 200
+    for i in range(0, len(ordered), chunk_size):
+        ok, output = _git_bytes(git_root, ["ls-files", "-z", "--", *ordered[i:i + chunk_size]])
+        if not ok:
+            return False
+        tracked.update(
+            p for p in output.decode("utf-8", errors="surrogateescape").split("\0") if p
+        )
+    return wanted <= tracked
 
 
 def stable_local_git_state(

--- a/src/jdocmunch_mcp/tools/doc_health_radar.py
+++ b/src/jdocmunch_mcp/tools/doc_health_radar.py
@@ -67,13 +67,17 @@ def doc_health_radar(
         drift_alarm=drift_alarm,
     )
 
+    result = {
+        "repo": health.get("repo", repo),
+        "section_count": section_count,
+        "doc_count": int(health.get("doc_count") or 0),
+        "radar": radar,
+    }
+    if health.get("repo_at_sha"):
+        result["repo_at_sha"] = health["repo_at_sha"]
+
     return {
-        "result": {
-            "repo": health.get("repo", repo),
-            "section_count": section_count,
-            "doc_count": int(health.get("doc_count") or 0),
-            "radar": radar,
-        },
+        "result": result,
         "_meta": {
             "latency_ms": int((time.perf_counter() - t0) * 1000),
         },

--- a/src/jdocmunch_mcp/tools/get_doc_health.py
+++ b/src/jdocmunch_mcp/tools/get_doc_health.py
@@ -99,7 +99,7 @@ def get_doc_health(
     has_emb = index._has_embeddings()
     embedding_count = sum(1 for s in index.sections if s.get("embedding"))
 
-    return {
+    payload = {
         "repo": f"{owner}/{name}",
         "section_count": len(index.sections),
         "doc_count": len(index.doc_paths),
@@ -115,3 +115,9 @@ def get_doc_health(
             "indexed_at": index.indexed_at,
         },
     }
+    if index.head_sha:
+        payload["head_sha"] = index.head_sha
+    payload["source_dirty"] = bool(index.source_dirty)
+    if index.repo_at_sha:
+        payload["repo_at_sha"] = index.repo_at_sha
+    return payload

--- a/src/jdocmunch_mcp/tools/get_doc_health.py
+++ b/src/jdocmunch_mcp/tools/get_doc_health.py
@@ -118,6 +118,7 @@ def get_doc_health(
     if index.head_sha:
         payload["head_sha"] = index.head_sha
     payload["source_dirty"] = bool(index.source_dirty)
+    payload["sha_certified"] = bool(index.sha_certified)
     if index.repo_at_sha:
         payload["repo_at_sha"] = index.repo_at_sha
     return payload

--- a/src/jdocmunch_mcp/tools/get_index_overview.py
+++ b/src/jdocmunch_mcp/tools/get_index_overview.py
@@ -103,7 +103,7 @@ def get_index_overview(
         rows.sort(key=lambda r: (-r["section_count"], r[key]))
         return rows[:top_n]
 
-    return {
+    payload = {
         "repo": f"{owner}/{name}",
         "doc_count": len(doc_section_counts),
         "section_count": len(index.sections),
@@ -117,3 +117,9 @@ def get_index_overview(
             "top_n": top_n,
         },
     }
+    if index.head_sha:
+        payload["head_sha"] = index.head_sha
+    payload["source_dirty"] = bool(index.source_dirty)
+    if index.repo_at_sha:
+        payload["repo_at_sha"] = index.repo_at_sha
+    return payload

--- a/src/jdocmunch_mcp/tools/get_index_overview.py
+++ b/src/jdocmunch_mcp/tools/get_index_overview.py
@@ -120,6 +120,7 @@ def get_index_overview(
     if index.head_sha:
         payload["head_sha"] = index.head_sha
     payload["source_dirty"] = bool(index.source_dirty)
+    payload["sha_certified"] = bool(index.sha_certified)
     if index.repo_at_sha:
         payload["repo_at_sha"] = index.repo_at_sha
     return payload

--- a/src/jdocmunch_mcp/tools/index_file.py
+++ b/src/jdocmunch_mcp/tools/index_file.py
@@ -10,7 +10,7 @@ from ..storage import DocStore
 from ..storage.doc_store import normalize_commit_sha
 from ..summarizer import summarize_sections
 from ..embeddings import embed_sections
-from ._git import local_git_state
+from ._git import local_git_head, local_git_paths_dirty, local_git_paths_tracked
 
 
 def _find_owning_index(
@@ -122,17 +122,30 @@ def index_file(
         if candidate.exists():
             source_root = candidate.resolve()
     previous_sha = normalize_commit_sha(index.head_sha if index else None)
-    current_sha, worktree_dirty = local_git_state(source_root, scope_path=source_root)
+    previous_certified = bool(index is not None and index.sha_certified)
+    indexed_paths = set(index.doc_paths if index else [])
+    indexed_paths.add(rel_path)
+    paths_tracked = local_git_paths_tracked(source_root, indexed_paths)
+    paths_dirty = local_git_paths_dirty(source_root, indexed_paths)
+    current_sha = local_git_head(source_root)
     head_moved = bool(previous_sha and current_sha and previous_sha != current_sha)
     legacy_uncertified = bool(current_sha and not previous_sha)
     lost_git_context = bool(previous_sha and current_sha is None)
     head_sha = current_sha or previous_sha
     source_dirty = bool(
-        worktree_dirty
+        paths_dirty
         or head_moved
         or legacy_uncertified
         or lost_git_context
+        or (bool(head_sha) and not paths_tracked)
         or (index is not None and index.source_dirty)
+    )
+    sha_certified = bool(
+        previous_certified
+        and current_sha
+        and previous_sha == current_sha
+        and not source_dirty
+        and paths_tracked
     )
 
     # Preserve embedding parity: if the existing index has embeddings, embed new sections too.
@@ -151,6 +164,7 @@ def index_file(
         doc_types={ext: 1},
         head_sha=head_sha,
         source_dirty=source_dirty,
+        sha_certified=sha_certified,
         source_root=str(source_root),
     )
 
@@ -169,6 +183,7 @@ def index_file(
         result["head_sha"] = updated.head_sha
     if updated:
         result["source_dirty"] = bool(updated.source_dirty)
+        result["sha_certified"] = bool(updated.sha_certified)
     if updated and updated.repo_at_sha:
         result["repo_at_sha"] = updated.repo_at_sha
     return result

--- a/src/jdocmunch_mcp/tools/index_file.py
+++ b/src/jdocmunch_mcp/tools/index_file.py
@@ -9,19 +9,20 @@ from ..parser import parse_file, preprocess_content, ALL_EXTENSIONS
 from ..storage import DocStore
 from ..summarizer import summarize_sections
 from ..embeddings import embed_sections
+from ._git import local_git_state
 
 
 def _find_owning_index(
     file_path: Path,
     store: DocStore,
-) -> Optional[tuple[str, str, str]]:
+) -> Optional[tuple[str, str, str, Path]]:
     """Find which index owns a given file path.
 
     Walks up the directory tree from the file, checking each ancestor
     folder name against existing local indexes.  When a match is found,
     verifies that the relative path exists in the index's doc_paths.
 
-    Returns (owner, name, rel_path) or None.
+    Returns (owner, name, rel_path, source_root) or None.
     """
     file_path = file_path.resolve()
     parts = file_path.parts
@@ -51,12 +52,12 @@ def _find_owning_index(
             continue
 
         if rel_path in index.doc_paths or rel_path in index.file_hashes:
-            return ("local", folder_name, rel_path)
+            return ("local", folder_name, rel_path, candidate_root)
 
         # The file might be new (not yet in doc_paths) but under this root
         # Accept if the root contains other indexed files
         if index.doc_paths:
-            return ("local", folder_name, rel_path)
+            return ("local", folder_name, rel_path, candidate_root)
 
     return None
 
@@ -91,7 +92,7 @@ def index_file(
     if match is None:
         return {"success": False, "error": f"File not in any index: {file_path}", "exit_code": 1}
 
-    owner, name, rel_path = match
+    owner, name, rel_path, detected_root = match
     repo_id = f"{owner}/{name}"
 
     # Read and parse the file
@@ -114,6 +115,12 @@ def index_file(
     # Determine if this is a new or changed file
     index = store.load_index(owner, name)
     is_new = rel_path not in (index.file_hashes if index else {})
+    source_root = detected_root
+    if index is not None and getattr(index, "source_root", ""):
+        candidate = Path(index.source_root).expanduser()
+        if candidate.exists():
+            source_root = candidate.resolve()
+    head_sha, source_dirty = local_git_state(source_root, scope_path=path)
 
     # Preserve embedding parity: if the existing index has embeddings, embed new sections too.
     if index is not None and index._has_embeddings():
@@ -129,10 +136,13 @@ def index_file(
         new_sections=new_sections,
         raw_files={rel_path: content},
         doc_types={ext: 1},
+        head_sha=head_sha,
+        source_dirty=source_dirty,
+        source_root=str(source_root),
     )
 
     latency_ms = int((time.perf_counter() - t0) * 1000)
-    return {
+    result = {
         "success": True,
         "repo": repo_id,
         "file": rel_path,
@@ -142,6 +152,13 @@ def index_file(
         "exit_code": 0,
         "_meta": {"latency_ms": latency_ms},
     }
+    if updated and updated.head_sha:
+        result["head_sha"] = updated.head_sha
+    if updated:
+        result["source_dirty"] = bool(updated.source_dirty)
+    if updated and updated.repo_at_sha:
+        result["repo_at_sha"] = updated.repo_at_sha
+    return result
 
 
 def index_file_cli(file_path: str) -> dict:

--- a/src/jdocmunch_mcp/tools/index_file.py
+++ b/src/jdocmunch_mcp/tools/index_file.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from ..parser import parse_file, preprocess_content, ALL_EXTENSIONS
 from ..storage import DocStore
+from ..storage.doc_store import normalize_commit_sha
 from ..summarizer import summarize_sections
 from ..embeddings import embed_sections
 from ._git import local_git_state
@@ -120,7 +121,19 @@ def index_file(
         candidate = Path(index.source_root).expanduser()
         if candidate.exists():
             source_root = candidate.resolve()
-    head_sha, source_dirty = local_git_state(source_root, scope_path=path)
+    previous_sha = normalize_commit_sha(index.head_sha if index else None)
+    current_sha, worktree_dirty = local_git_state(source_root, scope_path=source_root)
+    head_moved = bool(previous_sha and current_sha and previous_sha != current_sha)
+    legacy_uncertified = bool(current_sha and not previous_sha)
+    lost_git_context = bool(previous_sha and current_sha is None)
+    head_sha = current_sha or previous_sha
+    source_dirty = bool(
+        worktree_dirty
+        or head_moved
+        or legacy_uncertified
+        or lost_git_context
+        or (index is not None and index.source_dirty)
+    )
 
     # Preserve embedding parity: if the existing index has embeddings, embed new sections too.
     if index is not None and index._has_embeddings():

--- a/src/jdocmunch_mcp/tools/index_local.py
+++ b/src/jdocmunch_mcp/tools/index_local.py
@@ -21,7 +21,7 @@ from ..storage import DocStore
 from ..storage.doc_store import normalize_commit_sha
 from ..summarizer import summarize_sections
 from ..embeddings import embed_sections, get_provider_name, should_embed
-from ._git import local_git_state, stable_local_git_state
+from ._git import local_git_head, local_git_paths_dirty, local_git_paths_tracked, stable_local_git_state
 from ._constants import SKIP_PATTERNS
 
 
@@ -42,6 +42,7 @@ def _add_commit_fields(result: dict, index) -> None:
     if index.head_sha:
         result["head_sha"] = index.head_sha
     result["source_dirty"] = bool(index.source_dirty)
+    result["sha_certified"] = bool(index.sha_certified)
     if index.repo_at_sha:
         result["repo_at_sha"] = index.repo_at_sha
 
@@ -343,7 +344,7 @@ def index_local(
         repo_name = name if name else folder_path.name
         owner = "local"
         repo_id = f"{owner}/{repo_name}"
-        initial_git_state = local_git_state(folder_path, scope_path=folder_path)
+        initial_git_state = (local_git_head(folder_path), False)
         store = DocStore(base_path=storage_path)
         existing_index = store.load_index(owner, repo_name)
 
@@ -363,8 +364,17 @@ def index_local(
             except Exception as e:
                 warnings.append(f"Failed to read {file_path}: {e}")
 
-        final_git_state = local_git_state(folder_path, scope_path=folder_path)
+        final_git_state = (local_git_head(folder_path), False)
         head_sha, source_dirty = stable_local_git_state(initial_git_state, final_git_state)
+        cert_paths = set(current_files.keys())
+        if existing_index is not None:
+            cert_paths.update(existing_index.doc_paths)
+        if local_git_paths_dirty(folder_path, cert_paths):
+            source_dirty = True
+        paths_tracked = local_git_paths_tracked(folder_path, current_files.keys())
+        if head_sha and not paths_tracked:
+            source_dirty = True
+        sha_certified = bool(head_sha and not source_dirty and paths_tracked)
 
         # --- Incremental path ---
         if incremental and existing_index is not None:
@@ -375,6 +385,7 @@ def index_local(
                 if (
                     normalize_commit_sha(existing_index.head_sha) != head_sha
                     or bool(existing_index.source_dirty) != bool(source_dirty)
+                    or bool(existing_index.sha_certified) != bool(sha_certified)
                     or getattr(existing_index, "source_root", "") != str(folder_path)
                 ):
                     updated = store.incremental_save(
@@ -383,6 +394,7 @@ def index_local(
                         new_sections=[], raw_files={}, doc_types={},
                         head_sha=head_sha,
                         source_dirty=source_dirty,
+                        sha_certified=sha_certified,
                         source_root=str(folder_path),
                     ) or existing_index
                 latency_ms = int((time.perf_counter() - t0) * 1000)
@@ -437,6 +449,7 @@ def index_local(
                 new_sections=new_sections, raw_files=raw_subset, doc_types=doc_types,
                 head_sha=head_sha,
                 source_dirty=source_dirty,
+                sha_certified=sha_certified,
                 source_root=str(folder_path),
             )
 
@@ -549,6 +562,7 @@ def index_local(
             doc_types=doc_types,
             head_sha=head_sha,
             source_dirty=source_dirty,
+            sha_certified=sha_certified,
             source_root=str(folder_path),
         )
 

--- a/src/jdocmunch_mcp/tools/index_local.py
+++ b/src/jdocmunch_mcp/tools/index_local.py
@@ -18,8 +18,10 @@ from ..security import (
     DEFAULT_MAX_FILE_SIZE,
 )
 from ..storage import DocStore
+from ..storage.doc_store import normalize_commit_sha
 from ..summarizer import summarize_sections
 from ..embeddings import embed_sections, get_provider_name, should_embed
+from ._git import local_git_state, stable_local_git_state
 from ._constants import SKIP_PATTERNS
 
 
@@ -32,6 +34,16 @@ def _load_gitignore(folder_path: Path) -> Optional[pathspec.PathSpec]:
         except Exception:
             pass
     return None
+
+
+def _add_commit_fields(result: dict, index) -> None:
+    if not index:
+        return
+    if index.head_sha:
+        result["head_sha"] = index.head_sha
+    result["source_dirty"] = bool(index.source_dirty)
+    if index.repo_at_sha:
+        result["repo_at_sha"] = index.repo_at_sha
 
 
 def _should_skip(rel_path: str) -> bool:
@@ -331,7 +343,9 @@ def index_local(
         repo_name = name if name else folder_path.name
         owner = "local"
         repo_id = f"{owner}/{repo_name}"
+        initial_git_state = local_git_state(folder_path, scope_path=folder_path)
         store = DocStore(base_path=storage_path)
+        existing_index = store.load_index(owner, repo_name)
 
         # Read all discovered files
         current_files: dict = {}
@@ -349,11 +363,28 @@ def index_local(
             except Exception as e:
                 warnings.append(f"Failed to read {file_path}: {e}")
 
+        final_git_state = local_git_state(folder_path, scope_path=folder_path)
+        head_sha, source_dirty = stable_local_git_state(initial_git_state, final_git_state)
+
         # --- Incremental path ---
-        if incremental and store.load_index(owner, repo_name) is not None:
+        if incremental and existing_index is not None:
             changed, new, deleted = store.detect_changes(owner, repo_name, current_files)
 
             if not changed and not new and not deleted:
+                updated = existing_index
+                if (
+                    normalize_commit_sha(existing_index.head_sha) != head_sha
+                    or bool(existing_index.source_dirty) != bool(source_dirty)
+                    or getattr(existing_index, "source_root", "") != str(folder_path)
+                ):
+                    updated = store.incremental_save(
+                        owner=owner, name=repo_name,
+                        changed_files=[], new_files=[], deleted_files=[],
+                        new_sections=[], raw_files={}, doc_types={},
+                        head_sha=head_sha,
+                        source_dirty=source_dirty,
+                        source_root=str(folder_path),
+                    ) or existing_index
                 latency_ms = int((time.perf_counter() - t0) * 1000)
                 nochange_result: dict = {
                     "success": True,
@@ -364,6 +395,7 @@ def index_local(
                     "changed": 0, "new": 0, "deleted": 0,
                     "_meta": {"latency_ms": latency_ms},
                 }
+                _add_commit_fields(nochange_result, updated)
                 # jdoc#15: report truncation even when nothing changed,
                 # since the visible-corpus boundary is unchanged.
                 if discovered_count > max_files:
@@ -403,6 +435,9 @@ def index_local(
                 owner=owner, name=repo_name,
                 changed_files=changed, new_files=new, deleted_files=deleted,
                 new_sections=new_sections, raw_files=raw_subset, doc_types=doc_types,
+                head_sha=head_sha,
+                source_dirty=source_dirty,
+                source_root=str(folder_path),
             )
 
             latency_ms = int((time.perf_counter() - t0) * 1000)
@@ -417,6 +452,7 @@ def index_local(
                 "semantic_search": use_embeddings and get_provider_name() is not None,
                 "_meta": {"latency_ms": latency_ms},
             }
+            _add_commit_fields(result, updated)
             # jdoc#15: surface truncation on the incremental path too.
             if discovered_count > max_files:
                 result["truncated"] = True
@@ -511,6 +547,8 @@ def index_local(
             sections=all_sections,
             raw_files=raw_files,
             doc_types=doc_types,
+            head_sha=head_sha,
+            source_dirty=source_dirty,
             source_root=str(folder_path),
         )
 
@@ -527,6 +565,7 @@ def index_local(
             "semantic_search": use_embeddings and get_provider_name() is not None,
             "_meta": {"latency_ms": latency_ms},
         }
+        _add_commit_fields(result, saved)
         if autotune_result is not None:
             result["autotune"] = autotune_result
 

--- a/src/jdocmunch_mcp/tools/index_repo.py
+++ b/src/jdocmunch_mcp/tools/index_repo.py
@@ -11,6 +11,7 @@ import httpx
 from ..parser import parse_file, preprocess_content, ALL_EXTENSIONS
 from ..security import is_secret_file
 from ..storage import DocStore
+from ..storage.doc_store import normalize_commit_sha
 from ..summarizer import summarize_sections
 from ..embeddings import embed_sections, get_provider_name, should_embed
 from ._constants import SKIP_PATTERNS
@@ -39,10 +40,14 @@ def _should_skip(path: str) -> bool:
 
 
 async def fetch_head_commit_sha(
-    owner: str, repo: str, token: Optional[str] = None, client: Optional[httpx.AsyncClient] = None
+    owner: str,
+    repo: str,
+    token: Optional[str] = None,
+    client: Optional[httpx.AsyncClient] = None,
+    ref: str = "HEAD",
 ) -> Optional[str]:
-    """Fetch the HEAD commit SHA cheaply (single lightweight request)."""
-    url = f"https://api.github.com/repos/{owner}/{repo}/commits/HEAD"
+    """Fetch a commit SHA cheaply (single lightweight request)."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits/{ref}"
     headers = {"Accept": "application/vnd.github.v3+json"}
     if token:
         headers["Authorization"] = f"token {token}"
@@ -50,19 +55,23 @@ async def fetch_head_commit_sha(
         if client:
             response = await client.get(url, headers=headers)
             response.raise_for_status()
-            return response.json().get("sha")
+            return normalize_commit_sha(response.json().get("sha"))
         async with httpx.AsyncClient(timeout=15.0) as c:
             response = await c.get(url, headers=headers)
             response.raise_for_status()
-            return response.json().get("sha")
+            return normalize_commit_sha(response.json().get("sha"))
     except Exception:
         return None
 
 
 async def fetch_repo_tree(
-    owner: str, repo: str, token: Optional[str] = None, client: Optional[httpx.AsyncClient] = None
+    owner: str,
+    repo: str,
+    token: Optional[str] = None,
+    client: Optional[httpx.AsyncClient] = None,
+    ref: str = "HEAD",
 ) -> list:
-    url = f"https://api.github.com/repos/{owner}/{repo}/git/trees/HEAD"
+    url = f"https://api.github.com/repos/{owner}/{repo}/git/trees/{ref}"
     params = {"recursive": "1"}
     headers = {"Accept": "application/vnd.github.v3+json"}
     if token:
@@ -80,17 +89,19 @@ async def fetch_repo_tree(
 async def fetch_file_content(
     owner: str, repo: str, path: str, token: Optional[str] = None,
     client: Optional[httpx.AsyncClient] = None,
+    ref: str = "HEAD",
 ) -> str:
     url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+    params = {"ref": ref}
     headers = {"Accept": "application/vnd.github.v3.raw"}
     if token:
         headers["Authorization"] = f"token {token}"
     if client:
-        response = await client.get(url, headers=headers)
+        response = await client.get(url, params=params, headers=headers)
         response.raise_for_status()
         return response.text
     async with httpx.AsyncClient() as c:
-        response = await c.get(url, headers=headers)
+        response = await c.get(url, params=params, headers=headers)
         response.raise_for_status()
         return response.text
 
@@ -98,9 +109,10 @@ async def fetch_file_content(
 async def fetch_gitignore(
     owner: str, repo: str, token: Optional[str] = None,
     client: Optional[httpx.AsyncClient] = None,
+    ref: str = "HEAD",
 ) -> Optional[str]:
     try:
-        return await fetch_file_content(owner, repo, ".gitignore", token, client=client)
+        return await fetch_file_content(owner, repo, ".gitignore", token, client=client, ref=ref)
     except Exception:
         return None
 
@@ -185,24 +197,37 @@ async def index_repo(
             existing = store.load_index(owner, repo)
             if existing and existing.head_sha:
                 current_sha = await fetch_head_commit_sha(owner, repo, github_token)
-                if current_sha and current_sha == existing.head_sha:
+                if current_sha and current_sha == normalize_commit_sha(existing.head_sha):
+                    updated = existing
+                    if existing.source_dirty:
+                        updated = store.incremental_save(
+                            owner=owner, name=repo,
+                            changed_files=[], new_files=[], deleted_files=[],
+                            new_sections=[], raw_files={}, doc_types={},
+                            head_sha=current_sha, source_dirty=False,
+                        ) or existing
                     latency_ms = int((time.perf_counter() - t0) * 1000)
-                    return {
+                    result = {
                         "success": True,
                         "message": "No changes detected (HEAD SHA unchanged)",
                         "repo": f"{owner}/{repo}",
                         "incremental": True,
                         "head_sha": current_sha,
+                        "source_dirty": False,
                         "changed": 0, "new": 0, "deleted": 0,
                         "_meta": {"latency_ms": latency_ms},
                     }
+                    if updated.repo_at_sha:
+                        result["repo_at_sha"] = updated.repo_at_sha
+                    return result
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             # Fetch HEAD SHA alongside tree (reuse connection)
             head_sha = await fetch_head_commit_sha(owner, repo, github_token, client=client)
+            tree_ref = head_sha or "HEAD"
 
             try:
-                tree_entries = await fetch_repo_tree(owner, repo, github_token, client=client)
+                tree_entries = await fetch_repo_tree(owner, repo, github_token, client=client, ref=tree_ref)
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 404:
                     return {"success": False, "error": f"Repository not found: {owner}/{repo}"}
@@ -211,7 +236,7 @@ async def index_repo(
                 raise
 
             gitignore_spec = None
-            gitignore_content = await fetch_gitignore(owner, repo, github_token, client=client)
+            gitignore_content = await fetch_gitignore(owner, repo, github_token, client=client, ref=tree_ref)
             if gitignore_content:
                 import pathspec
                 try:
@@ -228,7 +253,7 @@ async def index_repo(
             async def fetch_with_limit(path: str) -> tuple:
                 async with semaphore:
                     try:
-                        content = await fetch_file_content(owner, repo, path, github_token, client=client)
+                        content = await fetch_file_content(owner, repo, path, github_token, client=client, ref=tree_ref)
                         return path, content
                     except Exception:
                         return path, ""
@@ -254,15 +279,33 @@ async def index_repo(
             changed, new, deleted = store.detect_changes(owner, repo, current_files)
 
             if not changed and not new and not deleted:
+                existing = store.load_index(owner, repo)
+                updated = existing
+                if existing and (
+                    normalize_commit_sha(existing.head_sha) != head_sha
+                    or existing.source_dirty
+                ):
+                    updated = store.incremental_save(
+                        owner=owner, name=repo,
+                        changed_files=[], new_files=[], deleted_files=[],
+                        new_sections=[], raw_files={}, doc_types={},
+                        head_sha=head_sha, source_dirty=False,
+                    ) or existing
                 latency_ms = int((time.perf_counter() - t0) * 1000)
-                return {
+                result = {
                     "success": True,
                     "message": "No changes detected",
                     "repo": f"{owner}/{repo}",
                     "incremental": True,
+                    "source_dirty": False,
                     "changed": 0, "new": 0, "deleted": 0,
                     "_meta": {"latency_ms": latency_ms},
                 }
+                if head_sha:
+                    result["head_sha"] = head_sha
+                if updated and updated.repo_at_sha:
+                    result["repo_at_sha"] = updated.repo_at_sha
+                return result
 
             files_to_parse = set(changed) | set(new)
             new_sections = []
@@ -289,7 +332,7 @@ async def index_repo(
                 owner=owner, name=repo,
                 changed_files=changed, new_files=new, deleted_files=deleted,
                 new_sections=new_sections, raw_files=raw_subset, doc_types=doc_types,
-                head_sha=head_sha,
+                head_sha=head_sha, source_dirty=False,
             )
 
             latency_ms = int((time.perf_counter() - t0) * 1000)
@@ -301,10 +344,15 @@ async def index_repo(
                 "section_count": len(updated.sections) if updated else 0,
                 "indexed_at": updated.indexed_at if updated else "",
                 "semantic_search": use_embeddings and get_provider_name() is not None,
+                "source_dirty": False,
                 "_meta": {"latency_ms": latency_ms},
             }
             if warnings:
                 result["warnings"] = warnings
+            if updated.head_sha:
+                result["head_sha"] = updated.head_sha
+            if updated.repo_at_sha:
+                result["repo_at_sha"] = updated.repo_at_sha
             return result
 
         # --- Full index path ---
@@ -351,8 +399,13 @@ async def index_repo(
             "doc_types": doc_types,
             "files": parsed_files[:20],
             "semantic_search": use_embeddings and get_provider_name() is not None,
+            "source_dirty": False,
             "_meta": {"latency_ms": latency_ms},
         }
+        if saved.head_sha:
+            result["head_sha"] = saved.head_sha
+        if saved.repo_at_sha:
+            result["repo_at_sha"] = saved.repo_at_sha
 
         if warnings:
             result["warnings"] = warnings

--- a/src/jdocmunch_mcp/tools/index_repo.py
+++ b/src/jdocmunch_mcp/tools/index_repo.py
@@ -197,15 +197,13 @@ async def index_repo(
             existing = store.load_index(owner, repo)
             if existing and existing.head_sha:
                 current_sha = await fetch_head_commit_sha(owner, repo, github_token)
-                if current_sha and current_sha == normalize_commit_sha(existing.head_sha):
+                if (
+                    current_sha
+                    and current_sha == normalize_commit_sha(existing.head_sha)
+                    and existing.sha_certified
+                    and not existing.source_dirty
+                ):
                     updated = existing
-                    if existing.source_dirty:
-                        updated = store.incremental_save(
-                            owner=owner, name=repo,
-                            changed_files=[], new_files=[], deleted_files=[],
-                            new_sections=[], raw_files={}, doc_types={},
-                            head_sha=current_sha, source_dirty=False,
-                        ) or existing
                     latency_ms = int((time.perf_counter() - t0) * 1000)
                     result = {
                         "success": True,
@@ -214,6 +212,7 @@ async def index_repo(
                         "incremental": True,
                         "head_sha": current_sha,
                         "source_dirty": False,
+                        "sha_certified": True,
                         "changed": 0, "new": 0, "deleted": 0,
                         "_meta": {"latency_ms": latency_ms},
                     }
@@ -225,6 +224,7 @@ async def index_repo(
             # Fetch HEAD SHA alongside tree (reuse connection)
             head_sha = await fetch_head_commit_sha(owner, repo, github_token, client=client)
             tree_ref = head_sha or "HEAD"
+            sha_certified = bool(head_sha)
 
             try:
                 tree_entries = await fetch_repo_tree(owner, repo, github_token, client=client, ref=tree_ref)
@@ -284,12 +284,13 @@ async def index_repo(
                 if existing and (
                     normalize_commit_sha(existing.head_sha) != head_sha
                     or existing.source_dirty
+                    or bool(existing.sha_certified) != sha_certified
                 ):
                     updated = store.incremental_save(
                         owner=owner, name=repo,
                         changed_files=[], new_files=[], deleted_files=[],
                         new_sections=[], raw_files={}, doc_types={},
-                        head_sha=head_sha, source_dirty=False,
+                        head_sha=head_sha, source_dirty=False, sha_certified=sha_certified,
                     ) or existing
                 latency_ms = int((time.perf_counter() - t0) * 1000)
                 result = {
@@ -298,6 +299,7 @@ async def index_repo(
                     "repo": f"{owner}/{repo}",
                     "incremental": True,
                     "source_dirty": False,
+                    "sha_certified": sha_certified,
                     "changed": 0, "new": 0, "deleted": 0,
                     "_meta": {"latency_ms": latency_ms},
                 }
@@ -332,7 +334,7 @@ async def index_repo(
                 owner=owner, name=repo,
                 changed_files=changed, new_files=new, deleted_files=deleted,
                 new_sections=new_sections, raw_files=raw_subset, doc_types=doc_types,
-                head_sha=head_sha, source_dirty=False,
+                head_sha=head_sha, source_dirty=False, sha_certified=sha_certified,
             )
 
             latency_ms = int((time.perf_counter() - t0) * 1000)
@@ -345,6 +347,7 @@ async def index_repo(
                 "indexed_at": updated.indexed_at if updated else "",
                 "semantic_search": use_embeddings and get_provider_name() is not None,
                 "source_dirty": False,
+                "sha_certified": sha_certified,
                 "_meta": {"latency_ms": latency_ms},
             }
             if warnings:
@@ -387,6 +390,7 @@ async def index_repo(
             raw_files=raw_files,
             doc_types=doc_types,
             head_sha=head_sha,
+            sha_certified=sha_certified,
         )
 
         latency_ms = int((time.perf_counter() - t0) * 1000)
@@ -400,6 +404,7 @@ async def index_repo(
             "files": parsed_files[:20],
             "semantic_search": use_embeddings and get_provider_name() is not None,
             "source_dirty": False,
+            "sha_certified": sha_certified,
             "_meta": {"latency_ms": latency_ms},
         }
         if saved.head_sha:

--- a/src/jdocmunch_mcp/tools/search_sections.py
+++ b/src/jdocmunch_mcp/tools/search_sections.py
@@ -340,6 +340,9 @@ def search_sections(
         meta["semantic_weight"] = semantic_weight
     meta["lexical_engine"] = lexical_engine
     meta["freshness"] = freshness_summary
+    if index.head_sha:
+        meta["head_sha"] = index.head_sha
+    meta["source_dirty"] = bool(index.source_dirty)
     if role:
         meta["role_filter"] = role.strip().lower()
     if profile_norm:
@@ -464,10 +467,13 @@ def search_sections(
     if not has_emb and mode == "lexical":
         meta["tip"] = "Re-index with use_embeddings=True for semantic search (better recall on paraphrased queries)"
 
-    return {
+    payload = {
         "repo": f"{owner}/{name}",
         "query": query,
         "results": results,
         "result_count": len(results),
         "_meta": meta,
     }
+    if index.repo_at_sha:
+        payload["repo_at_sha"] = index.repo_at_sha
+    return payload

--- a/src/jdocmunch_mcp/tools/search_sections.py
+++ b/src/jdocmunch_mcp/tools/search_sections.py
@@ -343,6 +343,7 @@ def search_sections(
     if index.head_sha:
         meta["head_sha"] = index.head_sha
     meta["source_dirty"] = bool(index.source_dirty)
+    meta["sha_certified"] = bool(index.sha_certified)
     if role:
         meta["role_filter"] = role.strip().lower()
     if profile_norm:

--- a/tests/test_index_repo_sha.py
+++ b/tests/test_index_repo_sha.py
@@ -4,6 +4,9 @@ import importlib
 
 import pytest
 
+from jdocmunch_mcp.parser import parse_file
+from jdocmunch_mcp.storage.doc_store import DocStore
+
 
 @pytest.mark.asyncio
 async def test_index_repo_fetches_tree_and_content_at_resolved_sha(tmp_path, monkeypatch):
@@ -42,6 +45,107 @@ async def test_index_repo_fetches_tree_and_content_at_resolved_sha(tmp_path, mon
     assert result["success"] is True
     assert result["head_sha"] == sha
     assert result["source_dirty"] is False
+    assert result["sha_certified"] is True
+    assert result["repo_at_sha"] == f"octo/docs@{sha}"
+    assert refs == [
+        ("tree", sha),
+        ("gitignore", sha),
+        ("content", sha, "README.md"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_index_repo_fallback_to_head_is_not_certified(tmp_path, monkeypatch):
+    mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
+    refs = []
+
+    async def fake_head(owner, repo, token=None, client=None, ref="HEAD"):
+        return None
+
+    async def fake_tree(owner, repo, token=None, client=None, ref="HEAD"):
+        refs.append(("tree", ref))
+        return [{"type": "blob", "path": "README.md", "size": 64}]
+
+    async def fake_gitignore(owner, repo, token=None, client=None, ref="HEAD"):
+        refs.append(("gitignore", ref))
+        return None
+
+    async def fake_content(owner, repo, path, token=None, client=None, ref="HEAD"):
+        refs.append(("content", ref, path))
+        return "# README\n\nUnpinned content."
+
+    monkeypatch.setattr(mod, "fetch_head_commit_sha", fake_head)
+    monkeypatch.setattr(mod, "fetch_repo_tree", fake_tree)
+    monkeypatch.setattr(mod, "fetch_gitignore", fake_gitignore)
+    monkeypatch.setattr(mod, "fetch_file_content", fake_content)
+
+    result = await mod.index_repo(
+        "octo/docs",
+        use_ai_summaries=False,
+        use_embeddings=False,
+        storage_path=str(tmp_path),
+    )
+
+    assert result["success"] is True
+    assert "head_sha" not in result
+    assert result["source_dirty"] is False
+    assert result["sha_certified"] is False
+    assert "repo_at_sha" not in result
+    assert refs == [
+        ("tree", "HEAD"),
+        ("gitignore", "HEAD"),
+        ("content", "HEAD", "README.md"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_index_repo_recovers_legacy_matching_sha_via_pinned_fetch(tmp_path, monkeypatch):
+    mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
+    sha = "d" * 40
+    content = "# README\n\nPinned content."
+    store = DocStore(base_path=str(tmp_path))
+    store.save_index(
+        "octo",
+        "docs",
+        parse_file(content, "README.md", "octo/docs"),
+        {"README.md": content},
+        {".md": 1},
+        head_sha=sha,
+    )
+    refs = []
+
+    async def fake_head(owner, repo, token=None, client=None, ref="HEAD"):
+        return sha
+
+    async def fake_tree(owner, repo, token=None, client=None, ref="HEAD"):
+        refs.append(("tree", ref))
+        return [{"type": "blob", "path": "README.md", "size": 64}]
+
+    async def fake_gitignore(owner, repo, token=None, client=None, ref="HEAD"):
+        refs.append(("gitignore", ref))
+        return None
+
+    async def fake_content(owner, repo, path, token=None, client=None, ref="HEAD"):
+        refs.append(("content", ref, path))
+        return content
+
+    monkeypatch.setattr(mod, "fetch_head_commit_sha", fake_head)
+    monkeypatch.setattr(mod, "fetch_repo_tree", fake_tree)
+    monkeypatch.setattr(mod, "fetch_gitignore", fake_gitignore)
+    monkeypatch.setattr(mod, "fetch_file_content", fake_content)
+
+    result = await mod.index_repo(
+        "octo/docs",
+        use_ai_summaries=False,
+        use_embeddings=False,
+        storage_path=str(tmp_path),
+    )
+
+    assert result["success"] is True
+    assert result["changed"] == 0
+    assert result["head_sha"] == sha
+    assert result["source_dirty"] is False
+    assert result["sha_certified"] is True
     assert result["repo_at_sha"] == f"octo/docs@{sha}"
     assert refs == [
         ("tree", sha),

--- a/tests/test_index_repo_sha.py
+++ b/tests/test_index_repo_sha.py
@@ -1,0 +1,50 @@
+"""Commit-SHA handling for GitHub indexing."""
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_index_repo_fetches_tree_and_content_at_resolved_sha(tmp_path, monkeypatch):
+    mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
+    sha = "c" * 40
+    refs = []
+
+    async def fake_head(owner, repo, token=None, client=None, ref="HEAD"):
+        assert (owner, repo, ref) == ("octo", "docs", "HEAD")
+        return sha
+
+    async def fake_tree(owner, repo, token=None, client=None, ref="HEAD"):
+        refs.append(("tree", ref))
+        return [{"type": "blob", "path": "README.md", "size": 64}]
+
+    async def fake_gitignore(owner, repo, token=None, client=None, ref="HEAD"):
+        refs.append(("gitignore", ref))
+        return None
+
+    async def fake_content(owner, repo, path, token=None, client=None, ref="HEAD"):
+        refs.append(("content", ref, path))
+        return "# README\n\nPinned content."
+
+    monkeypatch.setattr(mod, "fetch_head_commit_sha", fake_head)
+    monkeypatch.setattr(mod, "fetch_repo_tree", fake_tree)
+    monkeypatch.setattr(mod, "fetch_gitignore", fake_gitignore)
+    monkeypatch.setattr(mod, "fetch_file_content", fake_content)
+
+    result = await mod.index_repo(
+        "octo/docs",
+        use_ai_summaries=False,
+        use_embeddings=False,
+        storage_path=str(tmp_path),
+    )
+
+    assert result["success"] is True
+    assert result["head_sha"] == sha
+    assert result["source_dirty"] is False
+    assert result["repo_at_sha"] == f"octo/docs@{sha}"
+    assert refs == [
+        ("tree", sha),
+        ("gitignore", sha),
+        ("content", sha, "README.md"),
+    ]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -174,6 +174,18 @@ class TestDocStore:
         )
         assert store.load_index(*store._resolve_repo(f"test/dirty@{sha}")) is None
 
+    def test_repo_at_sha_miss_cannot_collide_with_real_index(self, tmp_path):
+        store = make_store(tmp_path)
+        sections, raw_files, doc_types = make_sections_and_files()
+        store.save_index("local", "__repo_at_sha_not_found__", sections, raw_files, doc_types)
+
+        owner, name = store._resolve_repo(f"local/missing@{'a' * 40}")
+        assert store.load_index(owner, name) is None
+
+        real = store.load_index(*store._resolve_repo("local/__repo_at_sha_not_found__"))
+        assert real is not None
+        assert real.repo == "local/__repo_at_sha_not_found__"
+
 
 class TestDocIndexSearch:
     def setup_method(self):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -144,6 +144,36 @@ class TestDocStore:
         assert "foo-bar/baz" in repo_ids
         assert "foo/bar-baz" in repo_ids
 
+    def test_commit_metadata_exposes_repo_at_sha(self, tmp_path):
+        store = make_store(tmp_path)
+        sections, raw_files, doc_types = make_sections_and_files()
+        sha = "a" * 40
+        store.save_index("test", "repo", sections, raw_files, doc_types, head_sha=sha)
+
+        loaded = store.load_index("test", "repo")
+        assert loaded.head_sha == sha
+        assert loaded.repo_at_sha == f"test/repo@{sha}"
+
+        repos = store.list_repos()
+        assert repos[0]["head_sha"] == sha
+        assert repos[0]["repo_at_sha"] == f"test/repo@{sha}"
+        assert repos[0]["source_dirty"] is False
+
+    def test_repo_at_sha_resolves_only_matching_clean_index(self, tmp_path):
+        store = make_store(tmp_path)
+        sections, raw_files, doc_types = make_sections_and_files()
+        sha = "a" * 40
+        store.save_index("test", "repo", sections, raw_files, doc_types, head_sha=sha)
+
+        assert store._resolve_repo(f"test/repo@{sha.upper()}") == ("test", "repo")
+        assert store.load_index(*store._resolve_repo(f"test/repo@{'b' * 40}")) is None
+
+        store.save_index(
+            "test", "dirty", sections, raw_files, doc_types,
+            head_sha=sha, source_dirty=True,
+        )
+        assert store.load_index(*store._resolve_repo(f"test/dirty@{sha}")) is None
+
 
 class TestDocIndexSearch:
     def setup_method(self):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -144,7 +144,27 @@ class TestDocStore:
         assert "foo-bar/baz" in repo_ids
         assert "foo/bar-baz" in repo_ids
 
-    def test_commit_metadata_exposes_repo_at_sha(self, tmp_path):
+    def test_commit_metadata_exposes_repo_at_sha_when_certified(self, tmp_path):
+        store = make_store(tmp_path)
+        sections, raw_files, doc_types = make_sections_and_files()
+        sha = "a" * 40
+        store.save_index(
+            "test", "repo", sections, raw_files, doc_types,
+            head_sha=sha, sha_certified=True,
+        )
+
+        loaded = store.load_index("test", "repo")
+        assert loaded.head_sha == sha
+        assert loaded.sha_certified is True
+        assert loaded.repo_at_sha == f"test/repo@{sha}"
+
+        repos = store.list_repos()
+        assert repos[0]["head_sha"] == sha
+        assert repos[0]["sha_certified"] is True
+        assert repos[0]["repo_at_sha"] == f"test/repo@{sha}"
+        assert repos[0]["source_dirty"] is False
+
+    def test_legacy_head_sha_without_certification_does_not_emit_repo_at_sha(self, tmp_path):
         store = make_store(tmp_path)
         sections, raw_files, doc_types = make_sections_and_files()
         sha = "a" * 40
@@ -152,25 +172,29 @@ class TestDocStore:
 
         loaded = store.load_index("test", "repo")
         assert loaded.head_sha == sha
-        assert loaded.repo_at_sha == f"test/repo@{sha}"
+        assert loaded.sha_certified is False
+        assert loaded.repo_at_sha is None
 
         repos = store.list_repos()
         assert repos[0]["head_sha"] == sha
-        assert repos[0]["repo_at_sha"] == f"test/repo@{sha}"
-        assert repos[0]["source_dirty"] is False
+        assert repos[0]["sha_certified"] is False
+        assert "repo_at_sha" not in repos[0]
 
     def test_repo_at_sha_resolves_only_matching_clean_index(self, tmp_path):
         store = make_store(tmp_path)
         sections, raw_files, doc_types = make_sections_and_files()
         sha = "a" * 40
-        store.save_index("test", "repo", sections, raw_files, doc_types, head_sha=sha)
+        store.save_index(
+            "test", "repo", sections, raw_files, doc_types,
+            head_sha=sha, sha_certified=True,
+        )
 
         assert store._resolve_repo(f"test/repo@{sha.upper()}") == ("test", "repo")
         assert store.load_index(*store._resolve_repo(f"test/repo@{'b' * 40}")) is None
 
         store.save_index(
             "test", "dirty", sections, raw_files, doc_types,
-            head_sha=sha, source_dirty=True,
+            head_sha=sha, source_dirty=True, sha_certified=True,
         )
         assert store.load_index(*store._resolve_repo(f"test/dirty@{sha}")) is None
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,6 @@
 """Tests for tool functions."""
 
+import shutil
 import subprocess
 
 import pytest
@@ -254,6 +255,163 @@ class TestIndexLocal:
         )
 
         assert updated["success"] is True
+        assert updated["source_dirty"] is True
+        assert "repo_at_sha" not in updated
+
+        repos = list_repos(storage_path=str(store_dir))
+        row = next(r for r in repos["repos"] if r["repo"] == "local/repo")
+        assert row["source_dirty"] is True
+        assert "repo_at_sha" not in row
+
+    def test_index_file_marks_dirty_when_sibling_doc_has_uncommitted_change(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        readme = repo_dir / "README.md"
+        guide = repo_dir / "GUIDE.md"
+        readme.write_text("# Readme\n\nClean", encoding="utf-8")
+        guide.write_text("# Guide\n\nClean", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", ".")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
+
+        indexed = index_local(
+            path=str(repo_dir),
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+        assert "repo_at_sha" in indexed
+
+        guide.write_text("# Guide\n\nDirty", encoding="utf-8")
+        updated = index_file(
+            file_path=str(readme),
+            use_ai_summaries=False,
+            storage_path=str(store_dir),
+        )
+
+        assert updated["success"] is True
+        assert updated["source_dirty"] is True
+        assert "repo_at_sha" not in updated
+
+        repos = list_repos(storage_path=str(store_dir))
+        row = next(r for r in repos["repos"] if r["repo"] == "local/repo")
+        assert row["source_dirty"] is True
+        assert "repo_at_sha" not in row
+
+    def test_index_file_marks_dirty_when_head_moves_for_sibling_doc(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        readme = repo_dir / "README.md"
+        guide = repo_dir / "GUIDE.md"
+        readme.write_text("# Readme\n\nClean", encoding="utf-8")
+        guide.write_text("# Guide\n\nVersion one", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", ".")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "v1")
+
+        indexed = index_local(
+            path=str(repo_dir),
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+        assert "repo_at_sha" in indexed
+
+        guide.write_text("# Guide\n\nVersion two", encoding="utf-8")
+        _git(repo_dir, "add", "GUIDE.md")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "v2")
+        new_sha = _git(repo_dir, "rev-parse", "HEAD")
+        updated = index_file(
+            file_path=str(readme),
+            use_ai_summaries=False,
+            storage_path=str(store_dir),
+        )
+
+        assert updated["success"] is True
+        assert updated["head_sha"] == new_sha
+        assert updated["source_dirty"] is True
+        assert "repo_at_sha" not in updated
+
+        repos = list_repos(storage_path=str(store_dir))
+        row = next(r for r in repos["repos"] if r["repo"] == "local/repo")
+        assert row["head_sha"] == new_sha
+        assert row["source_dirty"] is True
+        assert "repo_at_sha" not in row
+
+    def test_index_file_preserves_existing_dirty_state_after_worktree_clean(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        readme = repo_dir / "README.md"
+        guide = repo_dir / "GUIDE.md"
+        readme.write_text("# Readme\n\nClean", encoding="utf-8")
+        guide.write_text("# Guide\n\nClean", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", ".")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
+
+        indexed = index_local(
+            path=str(repo_dir),
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+        assert "repo_at_sha" in indexed
+
+        guide.write_text("# Guide\n\nDirty", encoding="utf-8")
+        dirty_update = index_file(
+            file_path=str(guide),
+            use_ai_summaries=False,
+            storage_path=str(store_dir),
+        )
+        assert dirty_update["source_dirty"] is True
+        _git(repo_dir, "checkout", "--", "GUIDE.md")
+
+        clean_file_update = index_file(
+            file_path=str(readme),
+            use_ai_summaries=False,
+            storage_path=str(store_dir),
+        )
+
+        assert clean_file_update["success"] is True
+        assert clean_file_update["source_dirty"] is True
+        assert "repo_at_sha" not in clean_file_update
+
+        repos = list_repos(storage_path=str(store_dir))
+        row = next(r for r in repos["repos"] if r["repo"] == "local/repo")
+        assert row["source_dirty"] is True
+        assert "repo_at_sha" not in row
+
+    def test_index_file_marks_dirty_when_git_context_disappears(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        readme = repo_dir / "README.md"
+        readme.write_text("# Clean\n\nBody", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", "README.md")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
+
+        indexed = index_local(
+            path=str(repo_dir),
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+        assert "repo_at_sha" in indexed
+
+        shutil.rmtree(repo_dir / ".git")
+        readme.write_text("# Changed\n\nOutside Git", encoding="utf-8")
+        updated = index_file(
+            file_path=str(readme),
+            use_ai_summaries=False,
+            storage_path=str(store_dir),
+        )
+
+        assert updated["success"] is True
+        assert updated["head_sha"] == indexed["head_sha"]
         assert updated["source_dirty"] is True
         assert "repo_at_sha" not in updated
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,11 +1,14 @@
 """Tests for tool functions."""
 
+import subprocess
+
 import pytest
 from pathlib import Path
 
 from jdocmunch_mcp.tools.index_local import _should_skip
 
 from jdocmunch_mcp.tools.index_local import index_local
+from jdocmunch_mcp.tools.index_file import index_file
 from jdocmunch_mcp.tools.list_repos import list_repos
 from jdocmunch_mcp.tools.delete_index import delete_index
 from jdocmunch_mcp.tools.get_toc import get_toc
@@ -15,8 +18,20 @@ from jdocmunch_mcp.tools.search_sections import search_sections
 from jdocmunch_mcp.tools.get_section import get_section
 from jdocmunch_mcp.tools.get_sections import get_sections
 from jdocmunch_mcp.tools.get_section_context import get_section_context
+import jdocmunch_mcp.tools._git as git_helpers
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    ).stdout.strip()
 
 
 @pytest.fixture
@@ -84,6 +99,168 @@ class TestIndexLocal:
         )
         assert result["success"] is True
         assert ".txt" in result["doc_types"]
+
+    def test_clean_git_repo_emits_repo_at_sha_and_alias_works(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        (repo_dir / "README.md").write_text("# Committed\n\nBody", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", "README.md")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
+        sha = _git(repo_dir, "rev-parse", "HEAD")
+
+        result = index_local(
+            path=str(repo_dir),
+            name="gitdocs",
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+
+        assert result["success"] is True
+        assert result["head_sha"] == sha
+        assert result["source_dirty"] is False
+        assert result["repo_at_sha"] == f"local/gitdocs@{sha}"
+
+        repos = list_repos(storage_path=str(store_dir))
+        row = next(r for r in repos["repos"] if r["repo"] == "local/gitdocs")
+        assert row["repo_at_sha"] == result["repo_at_sha"]
+        assert row["source_dirty"] is False
+
+        search = search_sections(
+            repo=result["repo_at_sha"],
+            query="Committed",
+            storage_path=str(store_dir),
+        )
+        assert "error" not in search
+        assert search["repo_at_sha"] == result["repo_at_sha"]
+
+    def test_dirty_git_repo_does_not_emit_repo_at_sha(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        readme = repo_dir / "README.md"
+        readme.write_text("# Clean\n\nBody", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", "README.md")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
+        sha = _git(repo_dir, "rev-parse", "HEAD")
+        readme.write_text("# Dirty\n\nChanged", encoding="utf-8")
+
+        result = index_local(
+            path=str(repo_dir),
+            name="gitdocs",
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+
+        assert result["success"] is True
+        assert result["head_sha"] == sha
+        assert result["source_dirty"] is True
+        assert "repo_at_sha" not in result
+
+    def test_dirty_files_outside_indexed_subdir_do_not_block_repo_at_sha(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        docs_dir = repo_dir / "docs"
+        src_dir = repo_dir / "src"
+        store_dir = tmp_path / "store"
+        docs_dir.mkdir(parents=True)
+        src_dir.mkdir()
+        (docs_dir / "README.md").write_text("# Docs\n\nCommitted", encoding="utf-8")
+        app = src_dir / "app.py"
+        app.write_text("print('clean')\n", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", ".")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "initial")
+        sha = _git(repo_dir, "rev-parse", "HEAD")
+        app.write_text("print('dirty')\n", encoding="utf-8")
+
+        result = index_local(
+            path=str(docs_dir),
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+
+        assert result["success"] is True
+        assert result["head_sha"] == sha
+        assert result["source_dirty"] is False
+        assert result["repo_at_sha"] == f"local/docs@{sha}"
+
+    def test_git_status_failure_does_not_emit_repo_at_sha(self, tmp_path, monkeypatch):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        (repo_dir / "README.md").write_text("# Clean\n\nBody", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", "README.md")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
+        sha = _git(repo_dir, "rev-parse", "HEAD")
+
+        real_run = subprocess.run
+
+        def flaky_run(args, *pargs, **kwargs):
+            if list(args[:2]) == ["git", "status"]:
+                raise subprocess.TimeoutExpired(args, 2)
+            return real_run(args, *pargs, **kwargs)
+
+        monkeypatch.setattr(git_helpers.subprocess, "run", flaky_run)
+
+        result = index_local(
+            path=str(repo_dir),
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+
+        assert result["success"] is True
+        assert result["head_sha"] == sha
+        assert result["source_dirty"] is True
+        assert "repo_at_sha" not in result
+
+    def test_sha_movement_during_local_index_is_dirty(self):
+        head_sha, dirty = git_helpers.stable_local_git_state(
+            ("a" * 40, False),
+            ("b" * 40, False),
+        )
+        assert head_sha == "b" * 40
+        assert dirty is True
+
+    def test_index_file_marks_clean_repo_dirty_after_edit(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        readme = repo_dir / "README.md"
+        readme.write_text("# Clean\n\nBody", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", "README.md")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
+
+        indexed = index_local(
+            path=str(repo_dir),
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+        assert "repo_at_sha" in indexed
+
+        readme.write_text("# Dirty\n\nChanged", encoding="utf-8")
+        updated = index_file(
+            file_path=str(readme),
+            use_ai_summaries=False,
+            storage_path=str(store_dir),
+        )
+
+        assert updated["success"] is True
+        assert updated["source_dirty"] is True
+        assert "repo_at_sha" not in updated
+
+        repos = list_repos(storage_path=str(store_dir))
+        row = next(r for r in repos["repos"] if r["repo"] == "local/repo")
+        assert row["source_dirty"] is True
+        assert "repo_at_sha" not in row
 
 
 class TestListRepos:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,8 @@
 """Tests for tool functions."""
 
+import os
 import shutil
+import stat
 import subprocess
 
 import pytest
@@ -33,6 +35,15 @@ def _git(cwd: Path, *args: str) -> str:
         text=True,
         check=True,
     ).stdout.strip()
+
+
+def _rmtree_force(path: Path) -> None:
+    """Remove trees containing read-only files, as Git can create on Windows."""
+    def onerror(func, file_path, _exc_info):
+        os.chmod(file_path, stat.S_IWRITE)
+        func(file_path)
+
+    shutil.rmtree(path, onerror=onerror)
 
 
 @pytest.fixture
@@ -570,7 +581,7 @@ class TestIndexLocal:
         )
         assert "repo_at_sha" in indexed
 
-        shutil.rmtree(repo_dir / ".git")
+        _rmtree_force(repo_dir / ".git")
         readme.write_text("# Changed\n\nOutside Git", encoding="utf-8")
         updated = index_file(
             file_path=str(readme),

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -122,12 +122,14 @@ class TestIndexLocal:
         assert result["success"] is True
         assert result["head_sha"] == sha
         assert result["source_dirty"] is False
+        assert result["sha_certified"] is True
         assert result["repo_at_sha"] == f"local/gitdocs@{sha}"
 
         repos = list_repos(storage_path=str(store_dir))
         row = next(r for r in repos["repos"] if r["repo"] == "local/gitdocs")
         assert row["repo_at_sha"] == result["repo_at_sha"]
         assert row["source_dirty"] is False
+        assert row["sha_certified"] is True
 
         search = search_sections(
             repo=result["repo_at_sha"],
@@ -160,6 +162,7 @@ class TestIndexLocal:
         assert result["success"] is True
         assert result["head_sha"] == sha
         assert result["source_dirty"] is True
+        assert result["sha_certified"] is False
         assert "repo_at_sha" not in result
 
     def test_dirty_files_outside_indexed_subdir_do_not_block_repo_at_sha(self, tmp_path):
@@ -188,9 +191,146 @@ class TestIndexLocal:
         assert result["success"] is True
         assert result["head_sha"] == sha
         assert result["source_dirty"] is False
+        assert result["sha_certified"] is True
         assert result["repo_at_sha"] == f"local/docs@{sha}"
 
-    def test_git_status_failure_does_not_emit_repo_at_sha(self, tmp_path, monkeypatch):
+    def test_dirty_tracked_unindexed_file_in_root_does_not_block_repo_at_sha(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        readme = repo_dir / "README.md"
+        helper = repo_dir / "helper.py"
+        readme.write_text("# Docs\n\nCommitted", encoding="utf-8")
+        helper.write_text("print('clean')\n", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", ".")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "initial")
+        sha = _git(repo_dir, "rev-parse", "HEAD")
+        helper.write_text("print('dirty')\n", encoding="utf-8")
+
+        result = index_local(
+            path=str(repo_dir),
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+
+        assert result["success"] is True
+        assert result["head_sha"] == sha
+        assert result["source_dirty"] is False
+        assert result["sha_certified"] is True
+        assert result["repo_at_sha"] == f"local/repo@{sha}"
+
+    def test_untracked_file_hidden_by_git_config_blocks_repo_at_sha(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        (repo_dir / "README.md").write_text("# Readme\n\nCommitted", encoding="utf-8")
+        (repo_dir / "UNTRACKED.md").write_text("# Untracked\n\nNot committed", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "config", "status.showUntrackedFiles", "no")
+        _git(repo_dir, "add", "README.md")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
+        sha = _git(repo_dir, "rev-parse", "HEAD")
+
+        result = index_local(
+            path=str(repo_dir),
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+
+        assert result["success"] is True
+        assert result["head_sha"] == sha
+        assert result["source_dirty"] is True
+        assert result["sha_certified"] is False
+        assert "repo_at_sha" not in result
+
+    def test_explicit_ignored_untracked_file_blocks_repo_at_sha(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        (repo_dir / ".gitignore").write_text("IGNORED.md\n", encoding="utf-8")
+        (repo_dir / "README.md").write_text("# Readme\n\nCommitted", encoding="utf-8")
+        (repo_dir / "IGNORED.md").write_text("# Ignored\n\nNot committed", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", ".gitignore", "README.md")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
+        sha = _git(repo_dir, "rev-parse", "HEAD")
+
+        result = index_local(
+            path=str(repo_dir),
+            paths=["IGNORED.md"],
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+
+        assert result["success"] is True
+        assert result["head_sha"] == sha
+        assert result["source_dirty"] is True
+        assert result["sha_certified"] is False
+        assert "repo_at_sha" not in result
+
+    def test_explicit_ignored_tracked_file_can_emit_repo_at_sha(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        (repo_dir / ".gitignore").write_text("IGNORED.md\n", encoding="utf-8")
+        (repo_dir / "IGNORED.md").write_text("# Ignored\n\nCommitted", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", ".gitignore")
+        _git(repo_dir, "add", "-f", "IGNORED.md")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
+        sha = _git(repo_dir, "rev-parse", "HEAD")
+
+        result = index_local(
+            path=str(repo_dir),
+            paths=["IGNORED.md"],
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+
+        assert result["success"] is True
+        assert result["head_sha"] == sha
+        assert result["source_dirty"] is False
+        assert result["sha_certified"] is True
+        assert result["repo_at_sha"] == f"local/repo@{sha}"
+
+    def test_untracked_non_indexed_clutter_does_not_block_repo_at_sha(self, tmp_path):
+        # A stray, unsupported, untracked file in the docs folder has no bearing
+        # on whether the indexed corpus is reproducible at HEAD, so it must not
+        # withhold the repo@sha handle (corpus-reproducible, not pristine-folder).
+        repo_dir = tmp_path / "repo"
+        store_dir = tmp_path / "store"
+        repo_dir.mkdir()
+        (repo_dir / "README.md").write_text("# Committed\n\nBody", encoding="utf-8")
+        _git(repo_dir, "init")
+        _git(repo_dir, "add", "README.md")
+        _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
+        sha = _git(repo_dir, "rev-parse", "HEAD")
+        # Unsupported extension → discovered-but-not-indexed → untracked clutter.
+        (repo_dir / "scratch.tmp").write_text("transient junk", encoding="utf-8")
+
+        result = index_local(
+            path=str(repo_dir),
+            use_ai_summaries=False,
+            use_embeddings=False,
+            storage_path=str(store_dir),
+        )
+
+        assert result["success"] is True
+        assert result["head_sha"] == sha
+        assert result["source_dirty"] is False
+        assert result["sha_certified"] is True
+        assert result["repo_at_sha"] == f"local/repo@{sha}"
+
+    def test_git_status_timeout_does_not_emit_repo_at_sha(self, tmp_path, monkeypatch):
+        # A blocked `git status` (e.g. index.lock contention) must hit the
+        # configured ceiling and fall to the safe "dirty / uncertified" side,
+        # never an unbounded hang. This also guards the regression where the
+        # subprocess timeout was dropped: production must pass it through.
         repo_dir = tmp_path / "repo"
         store_dir = tmp_path / "store"
         repo_dir.mkdir()
@@ -200,11 +340,15 @@ class TestIndexLocal:
         _git(repo_dir, "-c", "user.name=Test", "-c", "user.email=t@example.com", "commit", "-m", "docs")
         sha = _git(repo_dir, "rev-parse", "HEAD")
 
+        monkeypatch.setenv("JDOCMUNCH_GIT_TIMEOUT", "5")
         real_run = subprocess.run
 
         def flaky_run(args, *pargs, **kwargs):
             if list(args[:2]) == ["git", "status"]:
-                raise subprocess.TimeoutExpired(args, 2)
+                # Production must enforce a bounded timeout on every git call;
+                # simulate the configured ceiling firing on a hung status.
+                assert kwargs.get("timeout") == 5.0
+                raise subprocess.TimeoutExpired(args, kwargs["timeout"])
             return real_run(args, *pargs, **kwargs)
 
         monkeypatch.setattr(git_helpers.subprocess, "run", flaky_run)
@@ -219,7 +363,27 @@ class TestIndexLocal:
         assert result["success"] is True
         assert result["head_sha"] == sha
         assert result["source_dirty"] is True
+        assert result["sha_certified"] is False
         assert "repo_at_sha" not in result
+
+    def test_git_timeout_resolves_default_override_and_disable(self, monkeypatch):
+        monkeypatch.delenv("JDOCMUNCH_GIT_TIMEOUT", raising=False)
+        assert git_helpers._git_timeout() == git_helpers.DEFAULT_GIT_TIMEOUT
+
+        monkeypatch.setenv("JDOCMUNCH_GIT_TIMEOUT", "30")
+        assert git_helpers._git_timeout() == 30.0
+
+        # <= 0 explicitly disables the ceiling.
+        monkeypatch.setenv("JDOCMUNCH_GIT_TIMEOUT", "0")
+        assert git_helpers._git_timeout() is None
+        monkeypatch.setenv("JDOCMUNCH_GIT_TIMEOUT", "-5")
+        assert git_helpers._git_timeout() is None
+
+        # Unparseable / blank values fall back to the bounded default.
+        monkeypatch.setenv("JDOCMUNCH_GIT_TIMEOUT", "soon")
+        assert git_helpers._git_timeout() == git_helpers.DEFAULT_GIT_TIMEOUT
+        monkeypatch.setenv("JDOCMUNCH_GIT_TIMEOUT", "   ")
+        assert git_helpers._git_timeout() == git_helpers.DEFAULT_GIT_TIMEOUT
 
     def test_sha_movement_during_local_index_is_dirty(self):
         head_sha, dirty = git_helpers.stable_local_git_state(
@@ -256,6 +420,7 @@ class TestIndexLocal:
 
         assert updated["success"] is True
         assert updated["source_dirty"] is True
+        assert updated["sha_certified"] is False
         assert "repo_at_sha" not in updated
 
         repos = list_repos(storage_path=str(store_dir))
@@ -292,6 +457,7 @@ class TestIndexLocal:
 
         assert updated["success"] is True
         assert updated["source_dirty"] is True
+        assert updated["sha_certified"] is False
         assert "repo_at_sha" not in updated
 
         repos = list_repos(storage_path=str(store_dir))
@@ -332,6 +498,7 @@ class TestIndexLocal:
         assert updated["success"] is True
         assert updated["head_sha"] == new_sha
         assert updated["source_dirty"] is True
+        assert updated["sha_certified"] is False
         assert "repo_at_sha" not in updated
 
         repos = list_repos(storage_path=str(store_dir))
@@ -377,6 +544,7 @@ class TestIndexLocal:
 
         assert clean_file_update["success"] is True
         assert clean_file_update["source_dirty"] is True
+        assert clean_file_update["sha_certified"] is False
         assert "repo_at_sha" not in clean_file_update
 
         repos = list_repos(storage_path=str(store_dir))
@@ -413,6 +581,7 @@ class TestIndexLocal:
         assert updated["success"] is True
         assert updated["head_sha"] == indexed["head_sha"]
         assert updated["source_dirty"] is True
+        assert updated["sha_certified"] is False
         assert "repo_at_sha" not in updated
 
         repos = list_repos(storage_path=str(store_dir))


### PR DESCRIPTION
Closes #22

Follow-up from PR #17 

## Summary

This adds certified commit-pinned handles for doc indexes, so downstream MCP workflows can cite the exact documentation snapshot used for retrieval.

The new derived handle is:

```text
owner/repo@40hexsha
```

`repo_at_sha` is emitted only when the indexed corpus is certified to match that exact commit.

## What changed

- Add `head_sha`, `source_dirty`, `sha_certified`, and derived `repo_at_sha` metadata.
- Surface citation metadata in repo inventory, `search_sections`, `get_doc_health`, `get_index_overview`, and `doc_health_radar`.
- Resolve strict `repo@sha` handles only when the stored index matches the requested SHA and is certified clean.
- Certify local indexes against the indexed corpus, not unrelated dirty files in the worktree.
- Treat indexed untracked or ignored files as uncertified unless they are tracked.
- Keep `index_file` conservative so surgical updates cannot upgrade dirty, moved-HEAD, untracked-path, or no-longer-Git-backed indexes to certified.
- Certify GitHub indexes only after fetching content at the resolved commit SHA.
- Avoid strict-alias miss collisions with real repo names.

## Compatibility

This is additive. Existing repo names keep working.

`repo_at_sha` is derived, not stored, and is omitted unless all certification checks pass. Indexes with only `head_sha` metadata do not emit `repo_at_sha` until recertified.

## Out of scope

This PR intentionally does not add optional `doc_index_repo` name or alias overrides. That was mentioned alongside citeable index identity in the PR #17 thread, but it should remain a separate follow-up so this PR stays narrow.

## Testing

- `.venv/bin/python -m pytest tests/test_replay_metrics.py -q`
- `.venv/bin/python -m pytest tests/test_tools.py::TestIndexLocal tests/test_storage.py tests/test_index_repo_sha.py -q`
- `.venv/bin/python -m pytest tests/ -q`
- Manual MCP stdio validation for `index_local`, `doc_list_repos`, `search_sections`, `get_doc_health`, `get_index_overview`, and `delete_index`.
- CLI validation for `index-file` certification edge cases.
