### PR TITLE
index identity: add GitHub ref selection for versioned doc snapshots

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,6 +40,7 @@ Walks the local directory with full security controls: path traversal prevention
 ```json
 {
   "url": "owner/repo",
+  "ref": "optional-branch-tag-or-commit",
   "name": "optional-safe-storage-name",
   "use_ai_summaries": true,
   "incremental": true
@@ -48,9 +49,11 @@ Walks the local directory with full security controls: path traversal prevention
 
 Fetches documentation files via the GitHub API, parses sections, and saves to local storage.
 
+`ref` (optional): selects the GitHub branch, tag, or commit-ish to index. If omitted, `HEAD` is used. Explicit refs are resolved to a 40-hex commit SHA before fetching tree/content; unresolved explicit refs return an error instead of falling back to `HEAD`. Durable handles stay commit-SHA based via `repo_at_sha`.
+
 `name` (optional): stores the index under `owner/name` instead of `owner/repo`. This is a storage-name override, not a moving alias. The value must be a single safe storage component using only letters, numbers, dot, underscore, and hyphen; `/`, `\`, and `@` are rejected. GitHub indexing responses include the upstream source identity as `source_repo`, and certified indexes include both `repo_at_sha` for the stored index and `source_repo_at_sha` for the upstream GitHub repository.
 
-`incremental` (default `true`): first checks the HEAD commit SHA — if it matches the stored SHA the call returns immediately without any file fetches. If the SHA differs, only changed files are re-parsed. Set to `false` to force a full re-index.
+`incremental` (default `true`): first checks the selected GitHub ref's commit SHA — if it matches the stored SHA the call returns immediately without any file fetches. If the SHA differs, only changed files are re-parsed. Set to `false` to force a full re-index.
 
 #### `delete_index` — Delete index for a repository
 

--- a/src/jdocmunch_mcp/server.py
+++ b/src/jdocmunch_mcp/server.py
@@ -273,6 +273,10 @@ def _all_tools() -> list[Tool]:
                         "type": "string",
                         "description": "GitHub repository URL or owner/repo string"
                     },
+                    "ref": {
+                        "type": "string",
+                        "description": "Optional GitHub branch, tag, or commit-ish to index. If omitted, HEAD is used. The ref is resolved to a commit SHA before fetching content; repo@sha remains the durable lookup handle."
+                    },
                     "use_ai_summaries": {
                         "type": "boolean",
                         "description": "Use AI to generate section summaries.",
@@ -1685,6 +1689,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 storage_path=storage_path,
                 incremental=arguments.get("incremental", True),
                 name=arguments.get("name"),
+                ref=arguments.get("ref"),
             )
         elif name in ("doc_list_repos", "list_repos"):  # list_repos kept for backward compat
             result = list_repos(storage_path=storage_path)

--- a/src/jdocmunch_mcp/server.py
+++ b/src/jdocmunch_mcp/server.py
@@ -292,7 +292,7 @@ def _all_tools() -> list[Tool]:
                     },
                     "incremental": {
                         "type": "boolean",
-                        "description": "When true (default), skip all HTTP fetches if the HEAD commit SHA is unchanged; otherwise only re-index changed files. Set to false to force a full re-index.",
+                        "description": "When true (default), skip all HTTP fetches if the selected GitHub ref's commit SHA is unchanged; otherwise only re-index changed files. Set to false to force a full re-index.",
                         "default": True
                     }
                 },

--- a/src/jdocmunch_mcp/tools/index_repo.py
+++ b/src/jdocmunch_mcp/tools/index_repo.py
@@ -263,9 +263,14 @@ async def index_repo(
                             source_repo=source_repo_id,
                         ) or existing
                     latency_ms = int((time.perf_counter() - t0) * 1000)
+                    message = (
+                        "No changes detected (resolved ref SHA unchanged)"
+                        if explicit_ref
+                        else "No changes detected (HEAD SHA unchanged)"
+                    )
                     result = {
                         "success": True,
-                        "message": "No changes detected (HEAD SHA unchanged)",
+                        "message": message,
                         "repo": repo_id,
                         "incremental": True,
                         "head_sha": current_sha,
@@ -294,7 +299,10 @@ async def index_repo(
                 ref=requested_ref,
             )
             if explicit_ref and not head_sha:
-                return {"success": False, "error": f"GitHub ref not found: {owner}/{source_repo}@{requested_ref}"}
+                return {
+                    "success": False,
+                    "error": f"GitHub ref could not be resolved: {owner}/{source_repo}@{requested_ref}",
+                }
             tree_ref = head_sha or "HEAD"
             sha_certified = bool(head_sha)
 

--- a/src/jdocmunch_mcp/tools/index_repo.py
+++ b/src/jdocmunch_mcp/tools/index_repo.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 import time
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import httpx
 
@@ -31,6 +31,19 @@ def parse_github_url(url: str) -> tuple:
     raise ValueError(f"Could not parse GitHub URL: {url}")
 
 
+def _normalize_requested_ref(ref: Optional[str]) -> tuple[str, bool, Optional[str]]:
+    """Return (ref_to_resolve, was_explicit, error)."""
+    if ref is None:
+        return "HEAD", False, None
+    if not isinstance(ref, str):
+        return "", True, f"Invalid ref: {ref!r}"
+    original = ref
+    ref = ref.strip()
+    if not ref:
+        return "", True, f"Invalid ref: {original!r}"
+    return ref, True, None
+
+
 def _should_skip(path: str) -> bool:
     normalized = "/" + path.replace("\\", "/")
     for pat in SKIP_PATTERNS:
@@ -47,7 +60,8 @@ async def fetch_head_commit_sha(
     ref: str = "HEAD",
 ) -> Optional[str]:
     """Fetch a commit SHA cheaply (single lightweight request)."""
-    url = f"https://api.github.com/repos/{owner}/{repo}/commits/{ref}"
+    ref_path = quote(ref, safe="")
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits/{ref_path}"
     headers = {"Accept": "application/vnd.github.v3+json"}
     if token:
         headers["Authorization"] = f"token {token}"
@@ -176,6 +190,7 @@ async def index_repo(
     storage_path: Optional[str] = None,
     incremental: bool = True,
     name: Optional[str] = None,
+    ref: Optional[str] = None,
 ) -> dict:
     """Index a GitHub repository's documentation.
 
@@ -191,6 +206,7 @@ async def index_repo(
         storage_path: Custom storage path.
         incremental: When True and an existing index exists, only re-index changed files.
         name: Optional stored index name override. Defaults to the source repo name.
+        ref: Optional GitHub branch, tag, or commit-ish to index. Defaults to HEAD.
 
     Returns:
         Dict with indexing results.
@@ -205,6 +221,10 @@ async def index_repo(
 
     if not github_token:
         github_token = os.environ.get("GITHUB_TOKEN")
+
+    requested_ref, explicit_ref, ref_error = _normalize_requested_ref(ref)
+    if ref_error:
+        return {"success": False, "error": ref_error}
 
     warnings = []
 
@@ -225,7 +245,7 @@ async def index_repo(
             existing = store.load_index(owner, index_name)
             if existing and existing.head_sha:
                 existing_source_repo = existing.source_repo or existing.repo
-                current_sha = await fetch_head_commit_sha(owner, source_repo, github_token)
+                current_sha = await fetch_head_commit_sha(owner, source_repo, github_token, ref=requested_ref)
                 if (
                     current_sha
                     and current_sha == normalize_commit_sha(existing.head_sha)
@@ -265,8 +285,16 @@ async def index_repo(
                     )
 
         async with httpx.AsyncClient(timeout=30.0) as client:
-            # Fetch HEAD SHA alongside tree (reuse connection)
-            head_sha = await fetch_head_commit_sha(owner, source_repo, github_token, client=client)
+            # Resolve the requested ref once, then fetch all content at that SHA.
+            head_sha = await fetch_head_commit_sha(
+                owner,
+                source_repo,
+                github_token,
+                client=client,
+                ref=requested_ref,
+            )
+            if explicit_ref and not head_sha:
+                return {"success": False, "error": f"GitHub ref not found: {owner}/{source_repo}@{requested_ref}"}
             tree_ref = head_sha or "HEAD"
             sha_certified = bool(head_sha)
 

--- a/tests/test_index_repo_sha.py
+++ b/tests/test_index_repo_sha.py
@@ -217,7 +217,7 @@ async def test_index_repo_explicit_unknown_ref_fails_without_head_fallback(tmp_p
         storage_path=str(tmp_path),
     )
 
-    assert result == {"success": False, "error": "GitHub ref not found: octo/docs@missing-tag"}
+    assert result == {"success": False, "error": "GitHub ref could not be resolved: octo/docs@missing-tag"}
 
 
 @pytest.mark.asyncio
@@ -527,7 +527,7 @@ async def test_index_repo_ref_fast_path_uses_requested_ref(tmp_path, monkeypatch
     )
 
     assert result["success"] is True
-    assert result["message"] == "No changes detected (HEAD SHA unchanged)"
+    assert result["message"] == "No changes detected (resolved ref SHA unchanged)"
     assert result["repo"] == "octo/docs_v1"
     assert result["repo_at_sha"] == f"octo/docs_v1@{sha}"
     assert result["source_repo_at_sha"] == f"octo/docs@{sha}"

--- a/tests/test_index_repo_sha.py
+++ b/tests/test_index_repo_sha.py
@@ -108,6 +108,171 @@ async def test_index_repo_fallback_to_head_is_not_certified(tmp_path, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_index_repo_ref_fetches_tree_and_content_at_resolved_sha(tmp_path, monkeypatch):
+    mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
+    sha = "4" * 40
+    refs = []
+
+    async def fake_head(owner, repo, token=None, client=None, ref="HEAD"):
+        assert (owner, repo, ref) == ("octo", "docs", "v1.2.3")
+        return sha
+
+    async def fake_tree(owner, repo, token=None, client=None, ref="HEAD"):
+        refs.append(("tree", ref))
+        return [{"type": "blob", "path": "README.md", "size": 64}]
+
+    async def fake_gitignore(owner, repo, token=None, client=None, ref="HEAD"):
+        refs.append(("gitignore", ref))
+        return None
+
+    async def fake_content(owner, repo, path, token=None, client=None, ref="HEAD"):
+        refs.append(("content", ref, path))
+        return "# README\n\nVersioned content."
+
+    monkeypatch.setattr(mod, "fetch_head_commit_sha", fake_head)
+    monkeypatch.setattr(mod, "fetch_repo_tree", fake_tree)
+    monkeypatch.setattr(mod, "fetch_gitignore", fake_gitignore)
+    monkeypatch.setattr(mod, "fetch_file_content", fake_content)
+
+    result = await mod.index_repo(
+        "octo/docs",
+        ref="v1.2.3",
+        use_ai_summaries=False,
+        use_embeddings=False,
+        storage_path=str(tmp_path),
+    )
+
+    assert result["success"] is True
+    assert result["head_sha"] == sha
+    assert result["sha_certified"] is True
+    assert result["repo_at_sha"] == f"octo/docs@{sha}"
+    assert result["source_repo_at_sha"] == f"octo/docs@{sha}"
+    assert refs == [
+        ("tree", sha),
+        ("gitignore", sha),
+        ("content", sha, "README.md"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_index_repo_ref_composes_with_custom_name(tmp_path, monkeypatch):
+    mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
+    sha = "5" * 40
+
+    async def fake_head(owner, repo, token=None, client=None, ref="HEAD"):
+        assert (owner, repo, ref) == ("octo", "docs", "v1.2.3")
+        return sha
+
+    async def fake_tree(owner, repo, token=None, client=None, ref="HEAD"):
+        assert ref == sha
+        return [{"type": "blob", "path": "README.md", "size": 64}]
+
+    async def fake_gitignore(owner, repo, token=None, client=None, ref="HEAD"):
+        return None
+
+    async def fake_content(owner, repo, path, token=None, client=None, ref="HEAD"):
+        assert ref == sha
+        return "# README\n\nNamed versioned content."
+
+    monkeypatch.setattr(mod, "fetch_head_commit_sha", fake_head)
+    monkeypatch.setattr(mod, "fetch_repo_tree", fake_tree)
+    monkeypatch.setattr(mod, "fetch_gitignore", fake_gitignore)
+    monkeypatch.setattr(mod, "fetch_file_content", fake_content)
+
+    result = await mod.index_repo(
+        "octo/docs",
+        ref="v1.2.3",
+        name="docs_v1",
+        use_ai_summaries=False,
+        use_embeddings=False,
+        storage_path=str(tmp_path),
+    )
+
+    assert result["success"] is True
+    assert result["repo"] == "octo/docs_v1"
+    assert result["source_repo"] == "octo/docs"
+    assert result["repo_at_sha"] == f"octo/docs_v1@{sha}"
+    assert result["source_repo_at_sha"] == f"octo/docs@{sha}"
+
+
+@pytest.mark.asyncio
+async def test_index_repo_explicit_unknown_ref_fails_without_head_fallback(tmp_path, monkeypatch):
+    mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
+
+    async def fake_head(owner, repo, token=None, client=None, ref="HEAD"):
+        assert ref == "missing-tag"
+        return None
+
+    async def fake_tree(owner, repo, token=None, client=None, ref="HEAD"):
+        raise AssertionError("explicit missing ref should not fetch tree/content")
+
+    monkeypatch.setattr(mod, "fetch_head_commit_sha", fake_head)
+    monkeypatch.setattr(mod, "fetch_repo_tree", fake_tree)
+
+    result = await mod.index_repo(
+        "octo/docs",
+        ref="missing-tag",
+        use_ai_summaries=False,
+        use_embeddings=False,
+        storage_path=str(tmp_path),
+    )
+
+    assert result == {"success": False, "error": "GitHub ref not found: octo/docs@missing-tag"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_ref", ["", "   ", 123, [], {}])
+async def test_index_repo_rejects_invalid_ref_before_network_fetch(tmp_path, monkeypatch, bad_ref):
+    mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
+
+    async def fake_head(owner, repo, token=None, client=None, ref="HEAD"):
+        raise AssertionError("invalid ref should fail before network fetch")
+
+    monkeypatch.setattr(mod, "fetch_head_commit_sha", fake_head)
+
+    result = await mod.index_repo(
+        "octo/docs",
+        ref=bad_ref,
+        use_ai_summaries=False,
+        use_embeddings=False,
+        storage_path=str(tmp_path),
+    )
+
+    assert result["success"] is False
+    assert result["error"].startswith("Invalid ref:")
+
+
+@pytest.mark.asyncio
+async def test_fetch_head_commit_sha_url_encodes_ref_path_segment():
+    mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
+    sha = "6" * 40
+    seen = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"sha": sha}
+
+    class FakeClient:
+        async def get(self, url, headers=None):
+            seen["url"] = url
+            seen["headers"] = headers
+            return FakeResponse()
+
+    result = await mod.fetch_head_commit_sha(
+        "octo",
+        "docs",
+        client=FakeClient(),
+        ref="release/1.x",
+    )
+
+    assert result == sha
+    assert seen["url"].endswith("/repos/octo/docs/commits/release%2F1.x")
+
+
+@pytest.mark.asyncio
 async def test_index_repo_recovers_legacy_matching_sha_via_pinned_fetch(tmp_path, monkeypatch):
     mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
     sha = "d" * 40
@@ -326,6 +491,49 @@ async def test_index_repo_custom_name_fast_path_uses_override_storage(tmp_path, 
 
 
 @pytest.mark.asyncio
+async def test_index_repo_ref_fast_path_uses_requested_ref(tmp_path, monkeypatch):
+    mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
+    sha = "7" * 40
+    content = "# README\n\nCertified ref content."
+    store = DocStore(base_path=str(tmp_path))
+    store.save_index(
+        "octo",
+        "docs_v1",
+        parse_file(content, "README.md", "octo/docs_v1"),
+        {"README.md": content},
+        {".md": 1},
+        head_sha=sha,
+        sha_certified=True,
+        source_repo="octo/docs",
+    )
+
+    async def fake_head(owner, repo, token=None, client=None, ref="HEAD"):
+        assert (owner, repo, ref) == ("octo", "docs", "v1.2.3")
+        return sha
+
+    async def fake_tree(owner, repo, token=None, client=None, ref="HEAD"):
+        raise AssertionError("matching certified ref index should stay on SHA fast path")
+
+    monkeypatch.setattr(mod, "fetch_head_commit_sha", fake_head)
+    monkeypatch.setattr(mod, "fetch_repo_tree", fake_tree)
+
+    result = await mod.index_repo(
+        "octo/docs",
+        ref="v1.2.3",
+        name="docs_v1",
+        use_ai_summaries=False,
+        use_embeddings=False,
+        storage_path=str(tmp_path),
+    )
+
+    assert result["success"] is True
+    assert result["message"] == "No changes detected (HEAD SHA unchanged)"
+    assert result["repo"] == "octo/docs_v1"
+    assert result["repo_at_sha"] == f"octo/docs_v1@{sha}"
+    assert result["source_repo_at_sha"] == f"octo/docs@{sha}"
+
+
+@pytest.mark.asyncio
 async def test_index_repo_custom_name_same_storage_different_source_does_not_fast_path(tmp_path, monkeypatch):
     mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
     sha = "2" * 40
@@ -435,6 +643,66 @@ async def test_index_repo_custom_name_changed_file_incremental_uses_override_sto
 
 
 @pytest.mark.asyncio
+async def test_index_repo_moved_ref_with_unchanged_docs_updates_sha_metadata(tmp_path, monkeypatch):
+    mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
+    state = {"sha": "8" * 40}
+    tree_refs = []
+
+    async def fake_head(owner, repo, token=None, client=None, ref="HEAD"):
+        assert ref == "release/1.x"
+        return state["sha"]
+
+    async def fake_tree(owner, repo, token=None, client=None, ref="HEAD"):
+        tree_refs.append(ref)
+        return [{"type": "blob", "path": "README.md", "size": 64}]
+
+    async def fake_gitignore(owner, repo, token=None, client=None, ref="HEAD"):
+        return None
+
+    async def fake_content(owner, repo, path, token=None, client=None, ref="HEAD"):
+        return "# README\n\nBranch content unchanged."
+
+    monkeypatch.setattr(mod, "fetch_head_commit_sha", fake_head)
+    monkeypatch.setattr(mod, "fetch_repo_tree", fake_tree)
+    monkeypatch.setattr(mod, "fetch_gitignore", fake_gitignore)
+    monkeypatch.setattr(mod, "fetch_file_content", fake_content)
+
+    first = await mod.index_repo(
+        "octo/docs",
+        ref="release/1.x",
+        name="docs_release",
+        use_ai_summaries=False,
+        use_embeddings=False,
+        storage_path=str(tmp_path),
+    )
+    state["sha"] = "9" * 40
+    second = await mod.index_repo(
+        "octo/docs",
+        ref="release/1.x",
+        name="docs_release",
+        use_ai_summaries=False,
+        use_embeddings=False,
+        storage_path=str(tmp_path),
+    )
+
+    assert first["success"] is True
+    assert second["success"] is True
+    assert second["message"] == "No changes detected"
+    assert second["changed"] == 0
+    assert second["new"] == 0
+    assert second["deleted"] == 0
+    assert second["head_sha"] == "9" * 40
+    assert second["repo_at_sha"] == f"octo/docs_release@{'9' * 40}"
+    assert second["source_repo_at_sha"] == f"octo/docs@{'9' * 40}"
+    assert tree_refs == ["8" * 40, "9" * 40]
+
+    store = DocStore(base_path=str(tmp_path))
+    stored = store.load_index("octo", "docs_release")
+    assert stored is not None
+    assert stored.head_sha == "9" * 40
+
+
+@pytest.mark.asyncio
 async def test_index_repo_custom_name_fallback_to_head_is_not_certified(tmp_path, monkeypatch):
     mod = importlib.import_module("jdocmunch_mcp.tools.index_repo")
 
@@ -514,6 +782,8 @@ async def test_doc_index_repo_schema_exposes_name_override():
 
     assert "name" in tool.inputSchema["properties"]
     assert tool.inputSchema["properties"]["name"]["type"] == "string"
+    assert "ref" in tool.inputSchema["properties"]
+    assert tool.inputSchema["properties"]["ref"]["type"] == "string"
     assert tool.inputSchema["required"] == ["url"]
 
 
@@ -532,6 +802,7 @@ async def test_doc_index_repo_call_tool_passes_name_override(monkeypatch):
         "doc_index_repo",
         {
             "url": "octo/docs",
+            "ref": "v1.2.3",
             "name": "docs_v1",
             "use_ai_summaries": False,
             "use_embeddings": False,
@@ -541,6 +812,7 @@ async def test_doc_index_repo_call_tool_passes_name_override(monkeypatch):
 
     assert json.loads(response[0].text)["success"] is True
     assert seen["url"] == "octo/docs"
+    assert seen["ref"] == "v1.2.3"
     assert seen["name"] == "docs_v1"
     assert seen["use_ai_summaries"] is False
     assert seen["use_embeddings"] is False


### PR DESCRIPTION
Closes #26

Follow-up from PR #17.
Follow-up to PR #25.

## Summary

This adds an optional `ref` selector to `doc_index_repo`, so GitHub doc indexes can be built from a specific branch, tag, or commit-ish while preserving the existing commit-certified `repo@sha` citation model.

Without `ref`, behavior is unchanged:

```text
HEAD
```

With `ref`, the requested GitHub ref is resolved to a concrete commit SHA before fetching tree/content:

```text
v1.2.3 -> 40hexsha
release/1.x -> 40hexsha
```

The supplied `ref` is only selection input. Durable lookup/citation handles remain commit-SHA based:

```text
repo_at_sha: owner/custom_name@40hexsha
source_repo_at_sha: owner/repo@40hexsha
```

## What changed

- Add optional `ref` to `doc_index_repo` / `index_repo`.
- Resolve explicit refs to a commit SHA before fetching tree/content.
- Fetch the tree, `.gitignore`, and file content at the resolved SHA.
- URL-encode refs for the GitHub commits API so branch names containing `/` work.
- Fail closed for explicit unresolved refs instead of falling back to `HEAD`.
- Keep omitted-`ref` behavior unchanged, including existing uncertified fallback if `HEAD` SHA resolution fails.
- Compose `ref` with named indexes from PR #25.
- Update MCP schema, SPEC documentation, and focused ref-selection tests.

## Compatibility

This is additive. Existing `doc_index_repo(url="owner/repo")` behavior is unchanged.

`ref` is an input selector, not a lookup handle. Existing repo names, named indexes, strict `repo@sha` lookup, and local indexing behavior keep working.

## Out of scope

This PR intentionally does not add `owner/repo@main`, `owner/repo@v1.2.3`, or any other branch/tag/ref lookup handle.

It also does not add moving aliases, multiple aliases pointing to one index, historical snapshot retention, persisted ref identity, or changes to strict `repo@sha` semantics.

## Testing

- `uv run pytest tests/test_index_repo_sha.py -q`
- `uv run pytest tests/ -q`

Manual MCP validation:
- Indexed a real GitHub tag with `ref: v1.66.3`.
- Searched the named repo.
- Searched using strict `repo_at_sha`.
- Re-ran the same `ref`/`name` and hit the fast path.
- Indexed a branch ref containing `/`.
- Confirmed an explicit missing ref fails before tree/content fetch.
