### PR TITLE
fix: serialize concurrent index writes (cross-process lock + per-PID temp)

### DIFF
--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -5,11 +5,18 @@ import json
 import os
 import re
 import shutil
+import functools
 from collections import OrderedDict
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+
+try:
+    import fcntl  # POSIX advisory file locks (cross-process); absent on Windows
+except ImportError:  # pragma: no cover - non-POSIX fallback
+    fcntl = None
 
 from ..parser.sections import Section
 from ..embeddings import embed_query, cosine_similarity
@@ -17,6 +24,33 @@ from ..embeddings import embed_query, cosine_similarity
 INDEX_VERSION = 3
 COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 _UNSET = object()
+
+
+def _with_index_lock(method):
+    """Serialize same-repo index writes across processes (see DocStore._index_write_lock).
+
+    jdocmunch rewrites the whole ``<name>.json`` on every save. Without a
+    cross-process lock, two concurrent writers for the same repo (e.g. a
+    scheduled reindex and a per-edit hook) can interleave and ``os.replace``
+    then installs a corrupt/partial index, or silently drops one writer's
+    update (last-replace-wins). This decorator holds an exclusive advisory lock
+    for the whole method -- including the read in ``incremental_save`` -- so the
+    read-modify-write is atomic between processes.
+
+    Note: the lock is non-reentrant (``flock`` is per-fd), so a decorated method
+    must not call ``save_index``/``incremental_save`` for the *same* repo while
+    already holding the lock -- that would self-deadlock. Today neither writer
+    calls the other.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        owner = kwargs.get("owner", args[0] if len(args) >= 1 else None)
+        name = kwargs.get("name", args[1] if len(args) >= 2 else None)
+        with self._index_write_lock(owner, name):
+            return method(self, *args, **kwargs)
+
+    return wrapper
 
 # Module-level LRU cache: {(str(index_path), mtime_ns): DocIndex}
 # Keyed by path + mtime so the entry auto-invalidates whenever the file changes.
@@ -412,6 +446,34 @@ class DocStore:
         n = self._safe_repo_component(name, "name")
         return self.base_path / o / n
 
+    @contextmanager
+    def _index_write_lock(self, owner, name):
+        """Exclusive cross-process lock guarding writes to one repo's index.
+
+        Backed by an advisory ``flock`` on a per-repo ``<name>.json.lock`` file.
+        No-op when ``fcntl`` is unavailable (Windows) or owner/name are missing;
+        the per-PID temp name in the writers still prevents structural
+        corruption between processes in that case.
+        """
+        if fcntl is None or not owner or not name:
+            yield
+            return
+        try:
+            lock_path = self._index_path(owner, name).with_suffix(".json.lock")
+        except ValueError:
+            yield
+            return
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
     def _safe_content_path(self, content_dir: Path, relative_path: str) -> Optional[Path]:
         try:
             base = content_dir.resolve()
@@ -422,6 +484,7 @@ class DocStore:
         except (OSError, ValueError):
             return None
 
+    @_with_index_lock
     def save_index(
         self,
         owner: str,
@@ -467,7 +530,7 @@ class DocStore:
 
         index_path = self._index_path(owner, name)
         index_path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = index_path.with_suffix(".json.tmp")
+        tmp_path = index_path.with_name(f"{index_path.name}.{os.getpid()}.tmp")
         with open(tmp_path, "w", encoding="utf-8") as f:
             json.dump(self._index_to_dict(index), f, indent=2)
         tmp_path.replace(index_path)
@@ -579,6 +642,7 @@ class DocStore:
 
         return changed_files, new_files, deleted_files
 
+    @_with_index_lock
     def incremental_save(
         self,
         owner: str,
@@ -687,7 +751,7 @@ class DocStore:
 
         # Save atomically
         index_path = self._index_path(owner, name)
-        tmp_path = index_path.with_suffix(".json.tmp")
+        tmp_path = index_path.with_name(f"{index_path.name}.{os.getpid()}.tmp")
         with open(tmp_path, "w", encoding="utf-8") as f:
             json.dump(self._index_to_dict(updated), f, indent=2)
         tmp_path.replace(index_path)
@@ -800,6 +864,13 @@ class DocStore:
         if content_dir.exists():
             shutil.rmtree(content_dir)
             deleted = True
+        # Best-effort cleanup of the per-repo write-lock file left by _index_write_lock.
+        lock_path = index_path.with_suffix(".json.lock")
+        if lock_path.exists():
+            try:
+                lock_path.unlink()
+            except OSError:
+                pass
         return deleted
 
     def _index_to_dict(self, index: DocIndex) -> dict:

--- a/tests/test_concurrent_index_writes.py
+++ b/tests/test_concurrent_index_writes.py
@@ -1,0 +1,138 @@
+"""Regression tests for concurrent same-repo index writes.
+
+jdocmunch rewrites the whole ``<name>.json`` index on every save. Before the
+cross-process lock + per-PID temp name in ``DocStore.save_index`` /
+``incremental_save``, two processes writing the same repo shared the
+deterministic ``<name>.json.tmp`` with no lock, so ``os.replace`` could install
+corrupt/partial JSON (the repo then reads as both "corrupt" -- ``load_index``
+raises -- and "absent" -- ``list_repos`` drops it) or silently lose an update
+(last-replace-wins).
+
+These tests reproduce that race across real processes and assert it no longer
+corrupts the index or drops updates.
+"""
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+
+import pytest
+
+from jdocmunch_mcp.parser import parse_file
+from jdocmunch_mcp.storage.doc_store import DocStore
+
+try:
+    import fcntl  # noqa: F401
+
+    _HAS_FLOCK = True
+except ImportError:  # pragma: no cover - non-POSIX
+    _HAS_FLOCK = False
+
+_OWNER = "local"
+_NAME = "concurrent"
+
+
+def _join_all(procs, timeout: float = 120.0) -> None:
+    """Join workers, terminate any straggler, then assert all exited cleanly."""
+    for p in procs:
+        p.join(timeout=timeout)
+    for p in procs:
+        if p.is_alive():  # pragma: no cover - only on a hang
+            p.terminate()
+            p.join(timeout=10)
+    for p in procs:
+        assert p.exitcode == 0, f"writer process failed (exitcode={p.exitcode})"
+
+
+def _hammer_save(base_path: str, barrier, iters: int) -> None:
+    store = DocStore(base_path=base_path)
+    md = "# Root\n\nIntro.\n\n## A\n\nContent A.\n\n## B\n\nContent B.\n"
+    sections = parse_file(md, "README.md", f"{_OWNER}/{_NAME}")
+    raw_files = {"README.md": md}
+    doc_types = {".md": 1}
+    barrier.wait()  # start all writers together to maximize contention
+    for _ in range(iters):
+        store.save_index(_OWNER, _NAME, sections, raw_files, doc_types)
+
+
+def _add_one_doc(base_path: str, barrier, i: int) -> None:
+    store = DocStore(base_path=base_path)
+    doc = f"doc{i}.md"
+    md = f"# Doc {i}\n\nBody for doc {i} with enough text for a real section.\n"
+    new_sections = parse_file(md, doc, f"{_OWNER}/{_NAME}")
+    barrier.wait()
+    store.incremental_save(
+        _OWNER,
+        _NAME,
+        changed_files=[],
+        new_files=[doc],
+        deleted_files=[],
+        new_sections=new_sections,
+        raw_files={doc: md},
+        doc_types={".md": 1},
+    )
+
+
+def test_concurrent_save_no_corruption(tmp_path):
+    """N processes hammering save_index on the same repo never corrupt it.
+
+    The per-PID temp name fixes this even without the lock, so it runs on every
+    platform (including Windows where ``fcntl`` is unavailable).
+    """
+    base = str(tmp_path)
+    n_procs, iters = 8, 15
+    barrier = mp.Barrier(n_procs)
+    procs = [mp.Process(target=_hammer_save, args=(base, barrier, iters)) for _ in range(n_procs)]
+    for p in procs:
+        p.start()
+    _join_all(procs)
+
+    # The on-disk index must be valid JSON (raises JSONDecodeError if corrupt).
+    index_file = tmp_path / _OWNER / f"{_NAME}.json"
+    assert index_file.exists()
+    json.loads(index_file.read_text())
+
+    # And it must still load + list cleanly.
+    store = DocStore(base_path=base)
+    assert store.load_index(_OWNER, _NAME) is not None
+    assert any(r["repo"] == f"{_OWNER}/{_NAME}" for r in store.list_repos())
+
+    # No leftover temp files after success.
+    assert list((tmp_path / _OWNER).glob("*.tmp")) == []
+
+
+@pytest.mark.skipif(
+    not _HAS_FLOCK,
+    reason="lost-update prevention requires the cross-process flock (POSIX-only)",
+)
+def test_concurrent_incremental_no_lost_update(tmp_path):
+    """N processes each add a distinct doc via incremental_save; all survive.
+
+    Without the cross-process lock the workers all read the same base index and
+    last-replace-wins drops every addition but one. The flock serializes the
+    read-modify-write so every doc lands. (POSIX-only: the lock no-ops where
+    ``fcntl`` is unavailable, so the guarantee under test does not hold there.)
+    """
+    base = str(tmp_path)
+    base_md = "# Base\n\nBase content.\n"
+    DocStore(base_path=base).save_index(
+        _OWNER,
+        _NAME,
+        parse_file(base_md, "base.md", f"{_OWNER}/{_NAME}"),
+        {"base.md": base_md},
+        {".md": 1},
+    )
+
+    n = 8
+    barrier = mp.Barrier(n)
+    procs = [mp.Process(target=_add_one_doc, args=(base, barrier, i)) for i in range(n)]
+    for p in procs:
+        p.start()
+    _join_all(procs)
+
+    loaded = DocStore(base_path=base).load_index(_OWNER, _NAME)
+    assert loaded is not None
+    doc_paths = set(loaded.doc_paths)
+    expected = {"base.md"} | {f"doc{i}.md" for i in range(n)}
+    missing = expected - doc_paths
+    assert not missing, f"lost updates (last-writer-wins): missing {sorted(missing)}"


### PR DESCRIPTION
## Problem

`DocStore.save_index` and `incremental_save` each rewrite the **whole** `<name>.json` index on every save, but both wrote to a **shared, deterministic** temp file `<name>.json.tmp` with **no cross-process lock**. Two concurrent writers for the same repo — e.g. a scheduled/cron reindexer overlapping a per-edit hook, or two editor/agent sessions — could therefore:

- **Corrupt the index.** Both open the same `<name>.json.tmp`, their writes interleave, and whichever calls `tmp_path.replace(index_path)` last installs **invalid JSON**. The repo then reads as *both* "corrupt" (`load_index`'s unguarded `json.load` raises up through `search_sections`/`get_section`) **and** "absent" (`list_repos` swallows the parse error with `except: continue` and drops the repo).
- **Silently lose an update.** Each writer loads the same base index, rebuilds in memory, and replaces — last-replace-wins, so the other writer's sections vanish with no error.

This is not theoretical: it reproduced as a real "index went corrupt/absent after a heavy multi-writer session" incident. `verify-index` can't even diagnose it — it crashes on the unloadable JSON.

## Fix

1. **Per-repo exclusive advisory `flock`**, held across the *whole* read-modify-write (including the `load_index` in `incremental_save`), serializes same-repo writers across processes. Backed by a `<name>.json.lock` file; a small `_with_index_lock` decorator wraps both writers so there's no body churn.
2. **Per-PID temp names** (`<name>.json.<pid>.tmp`) so writers never share a temp file even where `flock` is unavailable (Windows: the lock no-ops, but per-PID temps still prevent structural corruption; only the lost-update guarantee is POSIX-only).

`delete_index` now cleans up the `.lock` file. The lock is non-reentrant (`flock` is per-fd) — documented in the decorator; neither writer calls the other, so there's no deadlock.

## Compatibility & scope

- **No public API change**; behaviour identical for the single-writer case.
- Cross-repo isolation unchanged (distinct names → distinct files/locks).
- Only the two `<name>.json` writers are touched; sidecar writers already write their own separate files atomically.
- Windows degrades gracefully (no `fcntl` → no crash; per-PID temp still prevents corruption).

## Tests

Adds `tests/test_concurrent_index_writes.py` — a **process-level** regression test that is **red without this patch** and green with it:

- `test_concurrent_save_no_corruption` — 8 processes hammer `save_index` on one repo; the on-disk JSON stays valid and the repo loads/lists. (Runs on all platforms — the per-PID temp fixes this without the lock.)
- `test_concurrent_incremental_no_lost_update` — 8 processes each add a distinct doc via `incremental_save`; **all** survive (POSIX-only; skipped where `fcntl` is unavailable, since the guarantee depends on the lock).

Against unpatched `doc_store.py` both fail with the shared-temp race (`FileNotFoundError` on `replace`, or missing docs). **Full suite: 1306 passed.**
