### PR TITLE
fix: redirect git subprocess stdin to DEVNULL to prevent stdio-server deadlock on Windows

### DIFF
--- a/src/jdocmunch_mcp/tools/_git.py
+++ b/src/jdocmunch_mcp/tools/_git.py
@@ -34,6 +34,11 @@ def _git(cwd: Path, args: list[str]) -> tuple[bool, str]:
         proc = subprocess.run(
             ["git", *args],
             cwd=str(cwd),
+            # stdin must be redirected: when the MCP server runs over stdio,
+            # an un-redirected git child inherits the JSON-RPC pipe as its
+            # stdin and Git for Windows blocks on it indefinitely (the
+            # timeout's kill-then-drain also wedges on the inherited handle).
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
@@ -50,6 +55,7 @@ def _git_bytes(cwd: Path, args: list[str]) -> tuple[bool, bytes]:
         proc = subprocess.run(
             ["git", *args],
             cwd=str(cwd),
+            stdin=subprocess.DEVNULL,  # see _git: prevents stdio-server deadlock
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             timeout=_git_timeout(),


### PR DESCRIPTION
## Summary

On Windows, every `index_local` call over the MCP stdio transport deadlocks the server permanently. The cause: `_git.py` spawns git via `subprocess.run` with `stdout=PIPE, stderr=DEVNULL` but **no `stdin` redirection**, so the git child inherits the server's stdin, which under stdio transport is the JSON-RPC pipe from the MCP client. Git for Windows blocks on that inherited pipe handle and never exits.

The existing `JDOCMUNCH_GIT_TIMEOUT` guard cannot recover from this: the 10s timeout fires and `subprocess.run` kills the direct child, but the post-kill `communicate()` drain then blocks forever joining the reader thread, because the `cmd\git.exe` wrapper chain still holds the inherited pipe handles. The server's event loop is wedged inside the synchronous tool call and never responds to anything again. (The `_git_timeout` docstring promises a blocked git "can never hang the synchronous tool path"; on Windows under stdio, it currently can.)

The fix is to pass `stdin=subprocess.DEVNULL` in `_git` and `_git_bytes`. No behavior change otherwise: none of the spawned git commands (`rev-parse`, `status --porcelain`, `ls-files`) read stdin.

## Why only the MCP path

- `jdocmunch-mcp index-local` (CLI) never hangs: its stdin is a console handle, not a pipe, so git does not block. This made the bug look transport-specific and hard to attribute.
- Read-only tools (`doc_list_repos`, `search_sections`, etc.) work fine over stdio; only the indexing tools touch `_git.py`.
- Both git and non-git target folders hang (a non-git folder still calls `local_git_head` -> `git rev-parse --is-inside-work-tree`).

## Diagnosis evidence

Reproduced outside any MCP client with a raw JSON-RPC stdio harness (initialize -> `tools/call index_local`): `initialize` responds, `index_local` never does. Launching the server with `faulthandler.dump_traceback_later(45)` armed captured the wedged stack:

```
Thread 0x00004488 (most recent call first):
  File "...\Lib\subprocess.py", line 1628 in _communicate
  File "...\Lib\subprocess.py", line 1209 in communicate
  File "...\Lib\subprocess.py", line 559 in run
  File "...\jdocmunch_mcp\tools\_git.py", line 34 in _git
  File "...\jdocmunch_mcp\tools\_git.py", line 64 in _git_root
  File "...\jdocmunch_mcp\tools\_git.py", line 74 in local_git_head
  File "...\jdocmunch_mcp\tools\index_local.py", line 347 in index_local
  File "...\jdocmunch_mcp\server.py", line 1662 in call_tool
  File "...\mcp\server\lowlevel\server.py", line 535 in handler
```

with a companion reader thread stuck in `subprocess.py _readerthread`, and the `git.exe rev-parse --is-inside-work-tree` child observed still alive well past the 10s timeout window.

With this patch applied to the same environment, the identical stdio harness calls complete in 0.1 to 0.6s (non-git folder full index, git folder incremental, git folder full re-index all green).

Environment: Windows 11, Python 3.12.13, Git for Windows resolved via `C:\Program Files\Git\cmd\git.exe`, jdocmunch-mcp 1.67.0 (bug still present in current `master`).
