### PR TITLE
Close Issue #95 retirement authority and public contention gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,17 @@ unverified recovery record; both fixed before this release shipped.
 - **QA-18:** corrected below — the #89 harness claim now states the exact
   results instead of "pass in full."
 
+**Issue #95 merge-closure candidate:** retirement publication is now
+commit-scoped: record creation, replacement, and removal are coordinated, final
+authorization requires the exact current publication, and fingerprints are
+re-proved after retained-handle coordination. Public `delete_index` makes one
+nonblocking lifecycle-coordination attempt while internal retirement keeps its
+bounded wait; successful deletion preserves the stable per-index lockfile.
+The public deleted, missing, and lifecycle-busy results have one authoritative
+runtime vocabulary, with a `SPEC.md` table and drift guard. QA-25's explicit
+caller wait policy and nonblocking default were preserved and independently
+verified, not redesigned.
+
 Additive and 1.x-compatible: new defaulted kwarg, new exception only raised
 when that kwarg is passed, new response keys, no INDEX_VERSION bump. Tests:
 `tests/test_v1_115_0.py` (10) + `tests/test_v1_115_0_qa89.py` (10) +

--- a/SPEC.md
+++ b/SPEC.md
@@ -461,16 +461,15 @@ signal and emits none of the four `retirement_cleanup_*` fields.
 | Field | JSON type | Allowed values | Meaning |
 |---|---|---|---|
 | `retirement_cleanup_pending` | `boolean` | `false`, `true` | True when durable record state remains readable or unreadable; false only when it is absent. |
-| `retirement_completion_marker_persisted` | `boolean` | `false`, `true` | True only when the exact publication durably records `completion_pending=true`; false otherwise. |
-| `retirement_cleanup_record_state` | `string` | `absent`, `readable`, `unreadable` | Observed durable retirement-record state after the completion and marker attempts. |
+| `retirement_cleanup_record_state` | `string` | `absent`, `readable`, `unreadable` | Observed durable retirement-record state after the completion attempt. |
 | `retirement_cleanup_owned` | `boolean` | `false`, `true` | True only for a readable record whose `publication_id` equals the exact completing publication; false for absent, unreadable, or replacement state. |
 
 `retirement_cleanup_pending` is derived from
 `retirement_cleanup_record_state`: it is false for `absent` and true for
 `readable` or `unreadable`. `retirement_cleanup_owned` is false when the record
-is absent, unreadable, or belongs to a replacement publication. A true
-`retirement_completion_marker_persisted` describes only the exact completing
-publication.
+is absent, unreadable, or belongs to a replacement publication. The fields
+report observed durable state only; the failed completion adds no further
+durable write while the record lock and retained gate are still held.
 
 ##### Retirement commit outcome matrix
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -380,8 +380,8 @@ supersession; jdoc#80 Parts B/C, #85, #86):
 | `superseded_by_established` | Git proved the provisional snapshot a strict ancestor of the established one (both certified clean); the older provisional was retired. |
 | `provisional_newer_than_established` | Git proved the provisional snapshot strictly newer; the established index is never replaced automatically — both kept, explicit refresh path reported. |
 | `supersession_conflict` | The target or candidate set changed before retirement; nothing removed, retry safe. |
-| `supersession_cleanup_incomplete` | Supersession proven but retirement did not complete; the provisional remains discoverable, retry idempotent. |
-| `graduation_cleanup_incomplete` | Exact-duplicate graduation proven but removing the provisional did not complete; nothing reconciled, the provisional remains discoverable, retry idempotent. |
+| `supersession_cleanup_incomplete` | Supersession was proven, but a pre-commit publication or cleanup failure prevented the primary unlink; the provisional remains discoverable and retry is idempotent. |
+| `graduation_cleanup_incomplete` | Exact-duplicate graduation was proven, but a pre-commit publication or cleanup failure prevented the primary unlink; nothing was reconciled, the provisional remains discoverable, and retry is idempotent. |
 | `graduation_conflict` | An index changed between the exact-duplicate proof and physical removal; the guarded delete voided the retirement before touching anything — both indexes kept, retry safe. |
 
 **`legacy_reconciliation.reason_code`** (Part C.2 — explicit-intent
@@ -398,15 +398,17 @@ ordinary refresh stays backfill-only and never retires anything):
 | `legacy_reconcile_ready` | Report mode: proof passed (single peer, same clean certified commit, full path-and-hash coverage); nothing was changed. |
 | `legacy_reconciled_to_established` | Apply mode: proof repeated immediately before retirement; the selected legacy handle was retired, the peer is unchanged and its handle returned. |
 | `legacy_reconcile_conflict` | The peer or candidate set changed between proof and retirement; nothing removed, retry safe. |
-| `legacy_reconcile_cleanup_incomplete` | Retirement proven but removal did not complete; the legacy index remains discoverable, retry idempotent. |
+| `legacy_reconcile_cleanup_incomplete` | Retirement was proven, but a pre-commit publication or cleanup failure prevented the primary unlink; the legacy index remains discoverable and retry is idempotent. |
 
 **Retirement coordination** (jdoc#88 QA-01/QA-02 + jdoc#89 QA-06..QA-11,
 v1.115.0): every retirement path (legacy apply, supersession, exact-dedup
 graduation) runs one coordinated destructive step. A guarded retirement
-requires a readable current retirement record with the exact current
-publication identity; record-path existence alone is not destructive
-authority. Missing or unreadable fingerprints, a missing or unreadable record,
-or a publication mismatch fail closed. `None` never authorizes removal.
+requires the explicit publication receipt created by its caller and a readable
+current retirement record with that exact current publication identity;
+record-path existence or a receiptless read of the current slot is not
+destructive authority. Missing or unreadable fingerprints, a missing or
+unreadable record, an omitted receipt, or a publication mismatch fail closed.
+`None` never authorizes removal.
 Monolith fingerprints for the retiring and retained handles may be checked
 earlier for fast rejection, but final authorization is proved only after the
 retained-handle gate is acquired and immediately before the primary
@@ -433,14 +435,19 @@ retirement before anything is removed. Completion, conflict cleanup, reverse
 scans, and stale repair acquire the record lock and revalidate the current
 record before unlinking it: stale or older cleanup cannot remove a newer
 publication. Each operation completes or cleans up only its exact publication.
-If record removal fails after the primary index is unlinked, failure after the
-primary unlink remains truthfully recoverable: the calling reconciliation
-family reports its cleanup-incomplete or pending outcome and the durable record
-remains. A fresh pending-state read self-heals the completed deletion instead
-of reporting false pending work, after rechecking under the record lock that
-the retiring monolith is still absent. A rewrite of either participant voids
-only the publication it revalidated; a failed save preserves the existing
-record.
+Every non-retired outcome occurs before the primary unlink and leaves the
+retiring monolith loadable. Cleanup-incomplete reason codes describe only a
+pre-commit failure, and a cleanup-incomplete outcome never follows a committed
+primary unlink. After the primary unlink commits, the retirement result is
+retired. If exact-publication record removal then fails, record cleanup failure
+is disclosed additively on that retired result, including whether the durable
+completion marker was persisted and whether a record remains. A fresh
+pending-state read rechecks under the record lock that the retiring monolith is
+still absent and self-heals the completed deletion when it can. A fresh
+pending-state read returns the durable record when self-healing cannot remove
+it, rather than falsely reporting no pending record. A rewrite of either
+participant voids only the publication it revalidated; a failed save preserves
+the existing record.
 
 Availability is commit-scoped. At the protected A-to-B commit, B is loadable
 and matches A's final authoritative proof. A change or removal of B before that

--- a/SPEC.md
+++ b/SPEC.md
@@ -458,7 +458,7 @@ the primary unlink committed but exact-publication record completion failed.
 They never describe a pre-commit conflict. If exact-publication record cleanup
 fails while a conflict has kept the retiring monolith loadable, the response
 instead reports `pending_retirement: true` as the durable pre-commit recovery
-signal and emits none of the four `retirement_cleanup_*` fields.
+signal and emits none of the `retirement_cleanup_*` fields.
 
 | Field | JSON type | Allowed values | Meaning |
 |---|---|---|---|
@@ -479,7 +479,7 @@ durable write while the record lock and retained gate are still held.
 |---|---|---|---|---|---|
 | Pre-commit refusal | `false` | non-retired | loadable | absent | Retry starts from the still-loadable retiring monolith. |
 | Committed with complete record cleanup | `true` | retired | absent | absent | No retirement cleanup remains for that exact publication. |
-| Committed with incomplete record cleanup | `true` | retired | absent | present | The four fields report durable state; a fresh pending read self-heals or returns the record. |
+| Committed with incomplete record cleanup | `true` | retired | absent | present | The cleanup fields report durable state; a fresh pending read self-heals or returns the record. |
 
 Availability is commit-scoped. At the protected A-to-B commit, B is loadable
 and matches A's final authoritative proof. A change or removal of B before that

--- a/SPEC.md
+++ b/SPEC.md
@@ -408,7 +408,9 @@ current retirement record with that exact current publication identity;
 record-path existence or a receiptless read of the current slot is not
 destructive authority. Missing or unreadable fingerprints, a missing or
 unreadable record, an omitted receipt, or a publication mismatch fail closed.
-`None` never authorizes removal.
+`None` never authorizes removal, and neither does an empty set of expected
+fingerprints: a proof that asserts nothing is refused rather than treated as
+an unguarded delete.
 Monolith fingerprints for the retiring and retained handles may be checked
 earlier for fast rejection, but final authorization is proved only after the
 retained-handle gate is acquired and immediately before the primary

--- a/SPEC.md
+++ b/SPEC.md
@@ -449,6 +449,33 @@ it, rather than falsely reporting no pending record. A rewrite of either
 participant voids only the publication it revalidated; a failed save preserves
 the existing record.
 
+##### Retirement cleanup disclosure schema
+
+These fields are additive and appear together only on a retired result when
+the primary unlink committed but exact-publication record completion failed.
+
+| Field | JSON type | Allowed values | Meaning |
+|---|---|---|---|
+| `retirement_cleanup_pending` | `boolean` | `false`, `true` | True when durable record state remains readable or unreadable; false only when it is absent. |
+| `retirement_completion_marker_persisted` | `boolean` | `false`, `true` | True only when the exact publication durably records `completion_pending=true`; false otherwise. |
+| `retirement_cleanup_record_state` | `string` | `absent`, `readable`, `unreadable` | Observed durable retirement-record state after the completion and marker attempts. |
+| `retirement_cleanup_owned` | `boolean` | `false`, `true` | True only for a readable record whose `publication_id` equals the exact completing publication; false for absent, unreadable, or replacement state. |
+
+`retirement_cleanup_pending` is derived from
+`retirement_cleanup_record_state`: it is false for `absent` and true for
+`readable` or `unreadable`. `retirement_cleanup_owned` is false when the record
+is absent, unreadable, or belongs to a replacement publication. A true
+`retirement_completion_marker_persisted` describes only the exact completing
+publication.
+
+##### Retirement commit outcome matrix
+
+| Scenario | Primary unlink committed | Returned retirement status | Retiring monolith | Cleanup fields | Durable recovery |
+|---|---|---|---|---|---|
+| Pre-commit refusal | `false` | non-retired | loadable | absent | Retry starts from the still-loadable retiring monolith. |
+| Committed with complete record cleanup | `true` | retired | absent | absent | No retirement cleanup remains for that exact publication. |
+| Committed with incomplete record cleanup | `true` | retired | absent | present | The four fields report durable state; a fresh pending read self-heals or returns the record. |
+
 Availability is commit-scoped. At the protected A-to-B commit, B is loadable
 and matches A's final authoritative proof. A change or removal of B before that
 commit forces A to re-prove or fail closed. After A commits and releases

--- a/SPEC.md
+++ b/SPEC.md
@@ -402,51 +402,53 @@ ordinary refresh stays backfill-only and never retires anything):
 
 **Retirement coordination** (jdoc#88 QA-01/QA-02 + jdoc#89 QA-06..QA-11,
 v1.115.0): every retirement path (legacy apply, supersession, exact-dedup
-graduation) runs one coordinated destructive step. Monolith fingerprints for
-the retiring AND retained handles are captured FIRST; the decisive proof
-predicates are then re-run on a reload the token covers, so a change landing
-around capture is re-proved rather than absorbed into the accepted token. A
-missing or unreadable fingerprint fails closed — `None` never authorizes a
-removal. The guarded `delete_index` (which holds the same cross-process
-write lock as the save paths) re-verifies the fingerprints twice inside the
-deletion boundary: at entry before any removal, and again immediately
-before the primary `<name>.json` record is removed — so a concurrent save or
-direct delete of either handle voids the retirement with every participating
-index still loadable. A mismatch fires the conflict reason codes above with
-a `changed_handles` list, both indexes kept. No successful retirement can
-remove the last surviving snapshot or return a retained handle that no
-longer exists.
+graduation) runs one coordinated destructive step. A guarded retirement
+requires a readable current retirement record with the exact current
+publication identity; record-path existence alone is not destructive
+authority. Missing or unreadable fingerprints, a missing or unreadable record,
+or a publication mismatch fail closed. `None` never authorizes removal.
+Monolith fingerprints for the retiring and retained handles may be checked
+earlier for fast rejection, but final authorization is proved only after the
+retained-handle gate is acquired and immediately before the primary
+`<name>.json` commit. At that point the guarded `delete_index` re-verifies
+every expected fingerprint and re-reads the exact publication while the
+retiring-handle lock, record lock, and retained gate remain held through the
+primary unlink and publication-scoped completion.
 
 The retirement record is the PAIR coordination point (jdoc#90 QA-17): the
-guarded delete executes its final gate — fingerprint re-verify, a check
-that its own durable record still exists, the primary unlink, and record
-removal — as one destructive step under a lock on that record. Any delete
-first voids the records naming its target as retained through the same
-lock, with a bounded wait, before its own destructive steps: a void landing
-before the gate makes the gate conflict (record gone, retiring handle
-kept); a delete arriving while the gate is closed is refused (returns
-False) and succeeds on retry once the gate opens. A completed retirement
-therefore always leaves the retained index in place at completion, and no
-interleaving of retirement with saves or deletes of either handle can end
-with both participating indexes absent. No caller ever blocks on two locks
-(handle locks and record locks are acquired in a fixed handle-then-record
-order, record locks non-blocking on the delete side), so the cross-handle
-deadlock surface stays closed.
+final step combines record coordination with a nonblocking retained-handle
+gate. Public deletion uses zero-wait coordination, while internal retirement
+uses its bounded wait where record voiding or cleanup must coordinate. A delete
+first revalidates and voids records naming its target as retained before its
+own destructive steps. A void landing before the final gate makes that gate
+conflict and keeps the retiring handle; a delete arriving while the gate is
+closed is refused and can succeed on retry. Path A keeps fixed
+handle-then-record ordering and never blocks on the retained gate, so it does
+not introduce pair locks, a second coordinator, or a cross-handle lock cycle.
 
 A durable retiring record (`<owner>/.retirements/<name>.json`) is published
-BEFORE the destructive step, fsync'd, with a per-publication-unique temp
-name, and the publication receipt is required — a failed publication stops
-the retirement before anything is removed (reported as the family's
-cleanup-incomplete code without a `pending_retirement` claim). The record is
-removed on success and on conflict, and kept when cleanup fails — responses
-then carry `pending_retirement: true` only when the record actually exists.
-A record whose retiring index no longer exists describes a completed
-retirement and is self-healed, never reported pending. A rewrite of the
-retiring handle cancels the pending retirement (only after the rewrite has
-durably landed — a failed save preserves the record); a rewrite or direct
-delete of the RETAINED handle likewise voids any record naming it as the
-retained peer. Fail-visible throughout: writes go where the caller aimed
-them, and the next reconcile re-proves against the current state.
+before the destructive step, fsync'd, with a per-publication-unique temp name,
+and the publication receipt is required. A failed publication stops the
+retirement before anything is removed. Completion, conflict cleanup, reverse
+scans, and stale repair acquire the record lock and revalidate the current
+record before unlinking it: stale or older cleanup cannot remove a newer
+publication. Each operation completes or cleans up only its exact publication.
+If record removal fails after the primary index is unlinked, failure after the
+primary unlink remains truthfully recoverable: the calling reconciliation
+family reports its cleanup-incomplete or pending outcome and the durable record
+remains. A fresh pending-state read self-heals the completed deletion instead
+of reporting false pending work, after rechecking under the record lock that
+the retiring monolith is still absent. A rewrite of either participant voids
+only the publication it revalidated; a failed save preserves the existing
+record.
+
+Availability is commit-scoped. At the protected A-to-B commit, B is loadable
+and matches A's final authoritative proof. A change or removal of B before that
+commit forces A to re-prove or fail closed. After A commits and releases
+coordination, a later separately authorized B-to-C retirement may legitimately
+remove B. No perpetual availability guarantee applies to historical A or B;
+each successful commit guarantees only that its retained successor is loadable
+at that protected commit.
 
 `legacy_reconcile="report"` performs no writes on any outcome: it proves
 from stored snapshots plus live Git evidence (both indexes certified clean

--- a/SPEC.md
+++ b/SPEC.md
@@ -453,6 +453,10 @@ the existing record.
 
 These fields are additive and appear together only on a retired result when
 the primary unlink committed but exact-publication record completion failed.
+They never describe a pre-commit conflict. If exact-publication record cleanup
+fails while a conflict has kept the retiring monolith loadable, the response
+instead reports `pending_retirement: true` as the durable pre-commit recovery
+signal and emits none of the four `retirement_cleanup_*` fields.
 
 | Field | JSON type | Allowed values | Meaning |
 |---|---|---|---|

--- a/SPEC.md
+++ b/SPEC.md
@@ -65,6 +65,17 @@ Fetches documentation files via the GitHub API, parses sections, and saves to lo
 
 Deletes both the index JSON and the raw content cache directory.
 
+##### Public result vocabulary
+
+| Outcome | `success` | `reason_code` | `retryable` |
+|---|---:|---|---:|
+| Deleted | `true` | `index_deleted` | `false` |
+| Missing | `false` | `index_not_found` | `false` |
+| Lifecycle contention | `false` | `index_lifecycle_busy` | `true` |
+
+Lifecycle contention returns promptly after one immediate coordination attempt,
+without a retry sleep. Internal retirement cleanup retains its bounded wait.
+
 ---
 
 ### Discovery Tools

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -31,6 +31,15 @@ INDEX_VERSION = 3
 COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 _UNSET = object()
 
+# Authoritative storage outcomes for delete_index. The semantic keys are
+# internal; the values are the stable public reason codes emitted by storage
+# and interpreted by the public tool.
+DELETE_REASON_CODES = {
+    "deleted": "index_deleted",
+    "not_found": "index_not_found",
+    "lifecycle_busy": "index_lifecycle_busy",
+}
+
 
 class RetirementConflict(Exception):
     """jdoc#88 QA-01: a guarded ``delete_index`` found an index changed since
@@ -101,7 +110,9 @@ def _with_index_lock(method):
                 if not acquired:
                     outcome = kwargs.get("outcome")
                     if outcome is not None:
-                        outcome["reason_code"] = "index_lifecycle_busy"
+                        outcome["reason_code"] = DELETE_REASON_CODES[
+                            "lifecycle_busy"
+                        ]
                     return False
                 return method(self, owner, name, *args, **kwargs)
         with self._index_write_lock(owner, name):
@@ -1694,7 +1705,7 @@ class DocStore:
             index_path = self._index_path(owner, name)
             content_dir = self._content_dir(owner, name)
         except ValueError:
-            _out("index_not_found")
+            _out(DELETE_REASON_CODES["not_found"])
             return False
 
         guarded_retirement = expected_fingerprints is not None
@@ -1725,7 +1736,7 @@ class DocStore:
         ):
             # A retirement owning this handle as its retained peer is inside
             # its destructive step right now. Retryable, and NOT missing.
-            _out("index_lifecycle_busy")
+            _out(DELETE_REASON_CODES["lifecycle_busy"])
             return False
 
         # jdoc#90 QA-17: note whether a durable record backs THIS guarded
@@ -1929,7 +1940,11 @@ class DocStore:
             pass
         if retirement_completion_failed:
             return False
-        _out("index_deleted" if deleted else "index_not_found")
+        _out(
+            DELETE_REASON_CODES["deleted"]
+            if deleted
+            else DELETE_REASON_CODES["not_found"]
+        )
         return deleted
 
     def _index_to_dict(self, index: DocIndex) -> dict:

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -44,12 +44,13 @@ DELETE_REASON_CODES = {
 class RetirementConflict(Exception):
     """jdoc#88 QA-01: a guarded ``delete_index`` found an index changed since
     its retirement was approved. Raised at the entry check (nothing touched)
-    or at the pre-removal recheck immediately before the primary record would
-    be unlinked (jdoc#89 QA-06) — in both cases every participating index
+    or at the final recheck after the retained-handle gate is acquired and
+    immediately before the primary record would be unlinked (jdoc#89 QA-06).
+    In both cases every participating index
     remains loadable; at worst rebuildable auxiliary artifacts of the
     retiring handle are gone. ``changed`` lists the ``owner/name`` handles
     that no longer match their proof-time fingerprints (an expected value of
-    None always conflicts — missing state never authorizes removal). Only
+    None always conflicts; missing state never authorizes removal). Only
     ever raised when the caller passed ``expected_fingerprints``; unguarded
     deletes are unaffected."""
 

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -40,6 +40,46 @@ DELETE_REASON_CODES = {
     "lifecycle_busy": "index_lifecycle_busy",
 }
 
+# Additive disclosure emitted only when a guarded retirement committed its
+# primary unlink but exact-publication record completion did not finish.
+# Field order is stable so the emitter can derive every public field name from
+# this lower-layer authority.
+RETIREMENT_CLEANUP_OUTCOME_SCHEMA = {
+    "retirement_cleanup_pending": {
+        "json_type": "boolean",
+        "allowed_values": ("false", "true"),
+        "meaning": (
+            "True when durable record state remains readable or unreadable; "
+            "false only when it is absent."
+        ),
+    },
+    "retirement_completion_marker_persisted": {
+        "json_type": "boolean",
+        "allowed_values": ("false", "true"),
+        "meaning": (
+            "True only when the exact publication durably records "
+            "completion_pending=true; false otherwise."
+        ),
+    },
+    "retirement_cleanup_record_state": {
+        "json_type": "string",
+        "allowed_values": ("absent", "readable", "unreadable"),
+        "meaning": (
+            "Observed durable retirement-record state after the completion "
+            "and marker attempts."
+        ),
+    },
+    "retirement_cleanup_owned": {
+        "json_type": "boolean",
+        "allowed_values": ("false", "true"),
+        "meaning": (
+            "True only for a readable record whose publication_id equals the "
+            "exact completing publication; false for absent, unreadable, or "
+            "replacement state."
+        ),
+    },
+}
+
 
 class RetirementConflict(Exception):
     """jdoc#88 QA-01: a guarded ``delete_index`` found an index changed since
@@ -1926,19 +1966,20 @@ class DocStore:
                                     )
                                 )
                                 if outcome is not None:
-                                    outcome["retirement_cleanup_pending"] = (
-                                        record_state != "absent"
-                                    )
-                                    outcome[
-                                        "retirement_completion_marker_persisted"
-                                    ] = marker_persisted
-                                    outcome["retirement_cleanup_record_state"] = (
-                                        record_state
-                                    )
-                                    outcome["retirement_cleanup_owned"] = (
+                                    cleanup_values = (
+                                        record_state != "absent",
+                                        marker_persisted,
+                                        record_state,
                                         durable_record is not None
                                         and durable_record.get("publication_id")
-                                        == expected_publication
+                                        == expected_publication,
+                                    )
+                                    outcome.update(
+                                        zip(
+                                            RETIREMENT_CLEANUP_OUTCOME_SCHEMA,
+                                            cleanup_values,
+                                            strict=True,
+                                        )
                                     )
                 except RetirementRecordLockError:
                     raise RetirementConflict([f"{owner}/{name}"])
@@ -1946,14 +1987,13 @@ class DocStore:
                 _evict_index_cache(index_path)
                 index_path.unlink()
                 deleted = True
-        # jdoc#88 QA-01/QA-02: once the primary record is gone the index has
-        # no pending retirement — the retirement completed, or a direct user
-        # delete of a retiring handle mooted it. Runs AFTER the primary
-        # removal so a failure part-way keeps the durable record (pending
-        # cleanup stays a discoverable fact). jdoc#89 QA-10: a direct delete
-        # also voids any record naming this handle as the RETAINED peer —
-        # that retirement can no longer complete as recorded. Best-effort,
-        # like claims.
+        # jdoc#88 QA-01/QA-02: after the primary commit the result is retired,
+        # but failed exact-publication completion can leave a durable cleanup
+        # record. Preserve that discoverable state for a fresh pending read;
+        # otherwise remove stale retiring records after the primary removal.
+        # jdoc#89 QA-10: a direct delete also voids records naming this handle
+        # as the retained peer. Both cleanup paths revalidate ownership and
+        # remain best-effort, like claims.
         try:
             from .retirements import (
                 void_retirement_if_stale, void_retirements_referencing,

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -41,9 +41,9 @@ DELETE_REASON_CODES = {
 }
 
 # Additive disclosure emitted only when a guarded retirement committed its
-# primary unlink but exact-publication record completion did not finish.
-# Field order is stable so the emitter can derive every public field name from
-# this lower-layer authority.
+# primary unlink but exact-publication record completion did not finish. This
+# is the single authority for the field names, types, and meanings that
+# SPEC.md publishes and the drift guard checks.
 RETIREMENT_CLEANUP_OUTCOME_SCHEMA = {
     "retirement_cleanup_pending": {
         "json_type": "boolean",
@@ -53,20 +53,12 @@ RETIREMENT_CLEANUP_OUTCOME_SCHEMA = {
             "false only when it is absent."
         ),
     },
-    "retirement_completion_marker_persisted": {
-        "json_type": "boolean",
-        "allowed_values": ("false", "true"),
-        "meaning": (
-            "True only when the exact publication durably records "
-            "completion_pending=true; false otherwise."
-        ),
-    },
     "retirement_cleanup_record_state": {
         "json_type": "string",
         "allowed_values": ("absent", "readable", "unreadable"),
         "meaning": (
             "Observed durable retirement-record state after the completion "
-            "and marker attempts."
+            "attempt."
         ),
     },
     "retirement_cleanup_owned": {
@@ -1939,48 +1931,38 @@ class DocStore:
                             if outcome is not None:
                                 outcome["_primary_unlink_committed"] = True
                             from .retirements import (
-                                _retirement_record_state,
-                                finish_retirement,
-                                mark_retirement_completion_pending,
+                                _retirement_record_state, finish_retirement,
                             )
-                            retirement_completion_failed = not finish_retirement(
-                                self.base_path,
-                                owner,
-                                name,
-                                publication_id=expected_publication,
-                                _lock_held=True,
+                            # Nothing after the unlink may add durable writes
+                            # to this critical section: the record lock and
+                            # the retained gate are both still held, and the
+                            # unlink that just failed is evidence the store is
+                            # already unhealthy. Read the durable state, tell
+                            # the caller, and get out.
+                            retirement_completion_failed = (
+                                not finish_retirement(
+                                    self.base_path, owner, name,
+                                    publication_id=expected_publication,
+                                    _lock_held=True,
+                                )
                             )
-                            if retirement_completion_failed:
-                                marker_persisted = (
-                                    mark_retirement_completion_pending(
-                                        self.base_path,
-                                        owner,
-                                        name,
-                                        publication_id=expected_publication,
-                                        _lock_held=True,
-                                    )
+                            if retirement_completion_failed and (
+                                outcome is not None
+                            ):
+                                state, record = _retirement_record_state(
+                                    self.base_path, owner, name
                                 )
-                                record_state, durable_record = (
-                                    _retirement_record_state(
-                                        self.base_path, owner, name
-                                    )
+                                outcome.update(
+                                    retirement_cleanup_pending=(
+                                        state != "absent"
+                                    ),
+                                    retirement_cleanup_record_state=state,
+                                    retirement_cleanup_owned=(
+                                        record is not None
+                                        and record.get("publication_id")
+                                        == expected_publication
+                                    ),
                                 )
-                                if outcome is not None:
-                                    cleanup_values = (
-                                        record_state != "absent",
-                                        marker_persisted,
-                                        record_state,
-                                        durable_record is not None
-                                        and durable_record.get("publication_id")
-                                        == expected_publication,
-                                    )
-                                    outcome.update(
-                                        zip(
-                                            RETIREMENT_CLEANUP_OUTCOME_SCHEMA,
-                                            cleanup_values,
-                                            strict=True,
-                                        )
-                                    )
                 except RetirementRecordLockError:
                     raise RetirementConflict([f"{owner}/{name}"])
             else:

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -754,12 +754,10 @@ class DocStore:
         self.base_path.mkdir(parents=True, exist_ok=True)
 
     def _safe_repo_component(self, value: str, field_name: str) -> str:
-        import re
-        if not value or value in {".", ".."}:
-            raise ValueError(f"Invalid {field_name}: {value!r}")
-        if "/" in value or "\\" in value:
-            raise ValueError(f"Invalid {field_name}: {value!r}")
-        if not re.fullmatch(r"[A-Za-z0-9._-]+", value):
+        # Shares retirements.is_safe_path_component so the store side and the
+        # record side cannot drift into two different notions of "safe".
+        from .retirements import is_safe_path_component
+        if not is_safe_path_component(value):
             raise ValueError(f"Invalid {field_name}: {value!r}")
         return value
 

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -1664,6 +1664,112 @@ class DocStore:
                 changed.append(handle)
         return changed
 
+    def _commit_guarded_retirement(
+        self, owner: str, name: str, index_path: Path, *,
+        expected_fingerprints: dict,
+        expected_publication: str,
+        entry_record: Optional[dict],
+        outcome: Optional[dict],
+    ) -> bool:
+        """The final authorization gate — the ONE destructive step.
+
+        jdoc#89 QA-06 / jdoc#90 QA-17 / jdoc#93 QA-19. Called holding this
+        handle's write lock, with every auxiliary artifact already removed and
+        the primary ``<name>.json`` still in place. Acquires the record lock,
+        then the retained peer's gate NONBLOCKINGLY, and holds both through
+        the unlink and publication-scoped completion.
+
+        Everything before the retained gate is fast rejection only. A
+        fingerprint read before that gate cannot see a writer already in
+        flight on the retained handle — one that passed its own void scan
+        before our record existed, or a save paused an instruction short of
+        ``_atomic_replace``. Both hold the retained handle's write lock, so
+        only the proof repeated AFTER the gate closes can authorize the
+        commit.
+
+        Returns True when exact-publication record completion also succeeded,
+        False when the primary unlink committed but that completion did not —
+        the caller must then leave the durable record alone as recoverable
+        state. Raises :class:`RetirementConflict` on any refusal, always
+        before the unlink, so the retiring monolith stays loadable; only
+        rebuildable auxiliary artifacts may already be gone.
+        """
+        from .retirements import (
+            _retirement_record_state, finish_retirement, hold_record_lock,
+            retirement_record, RetirementRecordLockError,
+        )
+
+        def _publication_conflict() -> RetirementConflict:
+            """Name the peer this retirement can no longer speak for."""
+            return RetirementConflict(
+                [(entry_record or {}).get("retained") or f"{owner}/{name}"]
+            )
+
+        def _authorized() -> bool:
+            current = retirement_record(self.base_path, owner, name)
+            return (
+                current is not None
+                and current.get("publication_id") == expected_publication
+            )
+
+        try:
+            with hold_record_lock(self.base_path, owner, name):
+                record = retirement_record(self.base_path, owner, name)
+                if (
+                    record is None
+                    or record.get("publication_id") != expected_publication
+                ):
+                    raise _publication_conflict()
+                retained = record.get("retained")
+                with self._gate_retained_handle(
+                    retained, owner, name
+                ) as gate_ok:
+                    if not gate_ok:
+                        raise RetirementConflict(
+                            [retained or f"{owner}/{name}"]
+                        )
+                    changed = self._verify_expected_fingerprints(
+                        expected_fingerprints
+                    )
+                    if changed:
+                        raise RetirementConflict(changed)
+                    if not _authorized():
+                        raise _publication_conflict()
+
+                    _evict_index_cache(index_path)
+                    index_path.unlink()
+                    if outcome is not None:
+                        outcome["_primary_unlink_committed"] = True
+
+                    # Past this point the retirement HAS committed. Add no
+                    # durable write to a critical section that still holds
+                    # both the record lock and the retained gate — a failed
+                    # completion is already evidence the store is unhealthy.
+                    # Read the durable state, disclose it, and get out.
+                    if finish_retirement(
+                        self.base_path, owner, name,
+                        publication_id=expected_publication,
+                        _lock_held=True,
+                    ):
+                        return True
+                    if outcome is not None:
+                        state, record = _retirement_record_state(
+                            self.base_path, owner, name
+                        )
+                        outcome.update(
+                            retirement_cleanup_pending=state != "absent",
+                            retirement_cleanup_record_state=state,
+                            retirement_cleanup_owned=(
+                                record is not None
+                                and record.get("publication_id")
+                                == expected_publication
+                            ),
+                        )
+                    return False
+        except RetirementRecordLockError:
+            # jdoc#95 AC-06: no authoritative lock, no critical section.
+            raise RetirementConflict([f"{owner}/{name}"])
+
     @_with_index_lock
     def delete_index(
         self,
@@ -1775,9 +1881,7 @@ class DocStore:
         # refuse the delete (retry succeeds as soon as the gate closes) so no
         # interleaving can end with both participating indexes absent.
         from .retirements import (
-            hold_record_lock,
             retirement_record,
-            RetirementRecordLockError,
             try_void_retirements_referencing,
         )
         if not try_void_retirements_referencing(
@@ -1867,113 +1971,16 @@ class DocStore:
         # index is gone; until then a failed earlier step leaves it loadable.
         if index_path.exists():
             if guarded_retirement:
-                # jdoc#89 QA-06 / jdoc#90 QA-17: the final gate. Everything
-                # inside the record lock is ONE destructive step: re-verify
-                # every proof-time fingerprint, require the durable record
-                # this retirement published to still exist, then unlink. A
-                # concurrent delete of the retained peer must first void that
-                # record through this same lock (try_void_retirements_
-                # referencing), so it either lands before the gate — record
-                # gone, conflict raised, this handle kept — or is refused
-                # until the gate closes. No interleaving finishes with both
-                # participating indexes absent. A conflict here leaves this
-                # handle loadable; only rebuildable auxiliary artifacts may
-                # already be gone (a refresh rebuilds them).
-                try:
-                    record_lock = hold_record_lock(
-                        self.base_path, owner, name
+                retirement_completion_failed = (
+                    not self._commit_guarded_retirement(
+                        owner, name, index_path,
+                        expected_fingerprints=expected_fingerprints,
+                        expected_publication=expected_publication,
+                        entry_record=entry_record,
+                        outcome=outcome,
                     )
-                    with record_lock:
-                        current_record = retirement_record(
-                            self.base_path, owner, name
-                        )
-                        if (
-                            current_record is None
-                            or current_record.get("publication_id")
-                            != expected_publication
-                        ):
-                            raise RetirementConflict(
-                                [
-                                    (entry_record or {}).get("retained")
-                                    or f"{owner}/{name}"
-                                ]
-                            )
-                        # jdoc#93 QA-19 (Path A): record identity is checked
-                        # above, but an early fingerprint cannot see work
-                        # already in flight on the retained handle. Take that
-                        # handle's gate nonblockingly, then repeat fingerprint
-                        # and record proof while both locks remain held through
-                        # unlink and publication-scoped completion.
-                        _retained = (current_record or {}).get("retained")
-                        with self._gate_retained_handle(
-                            _retained, owner, name
-                        ) as _gate_ok:
-                            if not _gate_ok:
-                                raise RetirementConflict(
-                                    [_retained or f"{owner}/{name}"]
-                                )
-                            # QA-19: retained coordination closes the in-flight
-                            # writer gap. Only proof performed after this point
-                            # can authorize the destructive commit.
-                            changed = self._verify_expected_fingerprints(
-                                expected_fingerprints
-                            )
-                            current_record = retirement_record(
-                                self.base_path, owner, name
-                            )
-                            if changed:
-                                raise RetirementConflict(changed)
-                            if (
-                                current_record is None
-                                or current_record.get("publication_id")
-                                != expected_publication
-                            ):
-                                raise RetirementConflict(
-                                    [
-                                        (entry_record or {}).get("retained")
-                                        or f"{owner}/{name}"
-                                    ]
-                                )
-                            _evict_index_cache(index_path)
-                            index_path.unlink()
-                            deleted = True
-                            if outcome is not None:
-                                outcome["_primary_unlink_committed"] = True
-                            from .retirements import (
-                                _retirement_record_state, finish_retirement,
-                            )
-                            # Nothing after the unlink may add durable writes
-                            # to this critical section: the record lock and
-                            # the retained gate are both still held, and the
-                            # unlink that just failed is evidence the store is
-                            # already unhealthy. Read the durable state, tell
-                            # the caller, and get out.
-                            retirement_completion_failed = (
-                                not finish_retirement(
-                                    self.base_path, owner, name,
-                                    publication_id=expected_publication,
-                                    _lock_held=True,
-                                )
-                            )
-                            if retirement_completion_failed and (
-                                outcome is not None
-                            ):
-                                state, record = _retirement_record_state(
-                                    self.base_path, owner, name
-                                )
-                                outcome.update(
-                                    retirement_cleanup_pending=(
-                                        state != "absent"
-                                    ),
-                                    retirement_cleanup_record_state=state,
-                                    retirement_cleanup_owned=(
-                                        record is not None
-                                        and record.get("publication_id")
-                                        == expected_publication
-                                    ),
-                                )
-                except RetirementRecordLockError:
-                    raise RetirementConflict([f"{owner}/{name}"])
+                )
+                deleted = True
             else:
                 _evict_index_cache(index_path)
                 index_path.unlink()

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -1705,21 +1705,34 @@ class DocStore:
                 [(entry_record or {}).get("retained") or f"{owner}/{name}"]
             )
 
-        def _authorized() -> bool:
-            current = retirement_record(self.base_path, owner, name)
-            return (
-                current is not None
-                and current.get("publication_id") == expected_publication
-            )
+        def _published_proof(current: Optional[dict]) -> dict:
+            """The durable proof this publication actually authorizes.
+
+            The receipt and the proof travel together or the receipt means
+            nothing: a caller holding a valid publication_id could otherwise
+            hand in an empty or partial map and have the gate verify only the
+            handles it chose to mention, so a changed retained peer would go
+            unnoticed. The record's own map is the authority, and the caller's
+            copy must equal it exactly.
+            """
+            if (
+                current is None
+                or current.get("publication_id") != expected_publication
+            ):
+                raise _publication_conflict()
+            published = current.get("fingerprints")
+            if (
+                not isinstance(published, dict)
+                or not published
+                or published != expected_fingerprints
+            ):
+                raise _publication_conflict()
+            return published
 
         try:
             with hold_record_lock(self.base_path, owner, name):
                 record = retirement_record(self.base_path, owner, name)
-                if (
-                    record is None
-                    or record.get("publication_id") != expected_publication
-                ):
-                    raise _publication_conflict()
+                _published_proof(record)
                 retained = record.get("retained")
                 with self._gate_retained_handle(
                     retained, owner, name
@@ -1728,13 +1741,15 @@ class DocStore:
                         raise RetirementConflict(
                             [retained or f"{owner}/{name}"]
                         )
-                    changed = self._verify_expected_fingerprints(
-                        expected_fingerprints
+                    # Re-read under the gate and verify the DURABLE map, not
+                    # the caller's argument, so the authority that authorizes
+                    # the unlink is the same object that recorded the proof.
+                    published = _published_proof(
+                        retirement_record(self.base_path, owner, name)
                     )
+                    changed = self._verify_expected_fingerprints(published)
                     if changed:
                         raise RetirementConflict(changed)
-                    if not _authorized():
-                        raise _publication_conflict()
 
                     _evict_index_cache(index_path)
                     index_path.unlink()
@@ -1906,6 +1921,13 @@ class DocStore:
         if guarded_retirement and (
             entry_record is None
             or entry_record.get("publication_id") != expected_publication
+            # Fast rejection of a proof this publication does not authorize.
+            # The final gate repeats it under the record lock; refusing here
+            # keeps auxiliary artifacts intact when the mismatch is already
+            # visible.
+            or not isinstance(entry_record.get("fingerprints"), dict)
+            or not entry_record.get("fingerprints")
+            or entry_record.get("fingerprints") != expected_fingerprints
         ):
             raise RetirementConflict([f"{owner}/{name}"])
 

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -1719,7 +1719,9 @@ class DocStore:
             try_void_retirements_referencing,
         )
         if not try_void_retirements_referencing(
-            self.base_path, f"{owner}/{name}"
+            self.base_path,
+            f"{owner}/{name}",
+            timeout_seconds=1.0 if lock_wait else 0.0,
         ):
             # A retirement owning this handle as its retained peer is inside
             # its destructive step right now. Retryable, and NOT missing.

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -1695,6 +1695,7 @@ class DocStore:
         from .retirements import (
             _retirement_record_state, finish_retirement, hold_record_lock,
             retirement_record, RetirementRecordLockError,
+            _valid_retirement_record,
         )
 
         def _publication_conflict() -> RetirementConflict:
@@ -1716,6 +1717,7 @@ class DocStore:
             if (
                 current is None
                 or current.get("publication_id") != expected_publication
+                or not _valid_retirement_record(current, owner, name)
             ):
                 raise _publication_conflict()
             published = current.get("fingerprints")

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -1573,10 +1573,17 @@ class DocStore:
         re-proves against the new state. Best-effort."""
         try:
             from .retirements import (
-                finish_retirement, void_retirements_referencing,
+                void_retirement_if_stale, void_retirements_referencing,
             )
-            finish_retirement(self.base_path, owner, name)
-            void_retirements_referencing(self.base_path, f"{owner}/{name}")
+            current_fingerprint = self.index_fingerprint(owner, name)
+            void_retirement_if_stale(
+                self.base_path, owner, name, current_fingerprint
+            )
+            void_retirements_referencing(
+                self.base_path,
+                f"{owner}/{name}",
+                current_fingerprint=current_fingerprint,
+            )
         except Exception:
             pass
 
@@ -1617,25 +1624,26 @@ class DocStore:
         expected_fingerprints: Optional[dict] = None,
         outcome: Optional[dict] = None,
         lock_wait: bool = False,
+        retirement_publication: Optional[str] = None,
     ) -> bool:
         """Delete an index and its raw content cache.
 
         Holds the same cross-process write lock as ``save_index`` /
         ``incremental_save`` (jdoc#89 QA-06: every writer and direct delete
-        of a handle joins one lifecycle coordinator — only the target handle
-        is locked, so lock ordering across handles never arises).
+        of a handle joins one lifecycle coordinator). Retirement additionally
+        takes the retained handle's gate nonblockingly only inside the final
+        commit, so it never waits while holding two handle locks.
 
         ``expected_fingerprints`` (jdoc#88 QA-01) maps ``owner/name`` handles
         to :meth:`index_fingerprint` values captured when the retirement was
         approved. The precondition is verified twice inside the deletion
         boundary: at entry before any removal (a mismatch raises
         :class:`RetirementConflict` with nothing touched), and again
-        immediately before the primary ``<name>.json`` record is removed
-        (jdoc#89 QA-06: auxiliary cleanup leaves a window a concurrent save
-        or direct delete of the OTHER handle can occupy — the second check
-        aborts with the handle still loadable; auxiliary artifacts may
-        already be gone, and a refresh rebuilds them). An expected value of
-        None always conflicts (missing state never authorizes removal).
+        after the retained gate is acquired and immediately before the primary
+        ``<name>.json`` record is removed. The second check aborts with the
+        handle still loadable when a concurrent save or direct delete changed
+        either participant; auxiliary artifacts may already be gone, and a
+        refresh rebuilds them. An expected value of None always conflicts.
         Omitted → the pre-existing unguarded behavior.
 
         jdoc#93 QA-20: ``outcome`` is an optional caller-supplied dict that
@@ -1706,6 +1714,8 @@ class DocStore:
         from .retirements import (
             hold_record_lock,
             pending_retirement,
+            retirement_record,
+            RetirementRecordLockError,
             try_void_retirements_referencing,
         )
         if not try_void_retirements_referencing(
@@ -1722,9 +1732,14 @@ class DocStore:
         # above, in another process) turns into a conflict, never a
         # completed retirement against a vanished peer.
         entry_record = (
-            pending_retirement(self.base_path, owner, name)
+            retirement_record(self.base_path, owner, name)
             if expected_fingerprints else None
         )
+        if retirement_publication is not None and (
+            entry_record is None
+            or entry_record.get("publication_id") != retirement_publication
+        ):
+            raise RetirementConflict([f"{owner}/{name}"])
 
         # jdoc#88 QA-02: remove the primary index record LAST. Auxiliary
         # artifacts (content cache, sidecars) go first; the `<name>.json`
@@ -1799,48 +1814,104 @@ class DocStore:
                 # participating indexes absent. A conflict here leaves this
                 # handle loadable; only rebuildable auxiliary artifacts may
                 # already be gone (a refresh rebuilds them).
-                with hold_record_lock(self.base_path, owner, name):
-                    changed = self._verify_expected_fingerprints(
-                        expected_fingerprints
-                    )
-                    if changed:
-                        raise RetirementConflict(changed)
-                    if entry_record is not None and pending_retirement(
+                try:
+                    record_lock = hold_record_lock(
                         self.base_path, owner, name
-                    ) is None:
-                        raise RetirementConflict(
-                            [entry_record.get("retained") or f"{owner}/{name}"]
+                    )
+                    with record_lock:
+                        current_record = retirement_record(
+                            self.base_path, owner, name
                         )
-                    # jdoc#93 QA-19 (Path A): the checks above prove the
-                    # retained peer has not changed YET and that our record
-                    # still exists. Neither can see work already IN FLIGHT on
-                    # the retained handle — a delete that passed its entry void
-                    # scan before our record existed, or a save paused one
-                    # instruction before _atomic_replace. Both hold the
-                    # retained handle's write lock, so take it here,
-                    # non-blocking, and hold it through the unlink and the
-                    # record removal. Failure means in-flight work: conflict
-                    # instead of completing, leaving BOTH indexes loadable.
-                    _retained = (entry_record or {}).get("retained")
-                    with self._gate_retained_handle(
-                        _retained, owner, name
-                    ) as _gate_ok:
-                        if not _gate_ok:
-                            raise RetirementConflict(
-                                [_retained or f"{owner}/{name}"]
+                        expected_publication = (
+                            retirement_publication
+                            or (entry_record or {}).get("publication_id")
+                        )
+                        if (
+                            expected_publication is not None
+                            and (
+                                current_record is None
+                                or current_record.get("publication_id")
+                                != expected_publication
                             )
-                        _evict_index_cache(index_path)
-                        index_path.unlink()
-                        deleted = True
-                        # Record removal inside the gate: the retirement is
-                        # complete the instant the lock releases, so no later
-                        # observer can see "index gone, record pending" from
-                        # this path (QA-08 self-heal still covers crashes).
-                        # Also inside the RETAINED handle's lock (QA-19), so
-                        # the whole destructive step is one interval no
-                        # retained-handle writer can interleave with.
-                        from .retirements import finish_retirement
-                        finish_retirement(self.base_path, owner, name)
+                        ):
+                            raise RetirementConflict(
+                                [
+                                    (entry_record or {}).get("retained")
+                                    or f"{owner}/{name}"
+                                ]
+                            )
+                        if (
+                            entry_record is not None
+                            and current_record is None
+                        ):
+                            raise RetirementConflict(
+                                [
+                                    entry_record.get("retained")
+                                    or f"{owner}/{name}"
+                                ]
+                            )
+                        # jdoc#93 QA-19 (Path A): record identity is checked
+                        # above, but an early fingerprint cannot see work
+                        # already in flight on the retained handle. Take that
+                        # handle's gate nonblockingly, then repeat fingerprint
+                        # and record proof while both locks remain held through
+                        # unlink and publication-scoped completion.
+                        _retained = (current_record or {}).get("retained")
+                        with self._gate_retained_handle(
+                            _retained, owner, name
+                        ) as _gate_ok:
+                            if not _gate_ok:
+                                raise RetirementConflict(
+                                    [_retained or f"{owner}/{name}"]
+                                )
+                            # QA-19: retained coordination closes the in-flight
+                            # writer gap. Only proof performed after this point
+                            # can authorize the destructive commit.
+                            changed = self._verify_expected_fingerprints(
+                                expected_fingerprints
+                            )
+                            current_record = retirement_record(
+                                self.base_path, owner, name
+                            )
+                            if changed:
+                                raise RetirementConflict(changed)
+                            if (
+                                expected_publication is not None
+                                and (
+                                    current_record is None
+                                    or current_record.get("publication_id")
+                                    != expected_publication
+                                )
+                            ):
+                                raise RetirementConflict(
+                                    [
+                                        (entry_record or {}).get("retained")
+                                        or f"{owner}/{name}"
+                                    ]
+                                )
+                            if (
+                                current_record is None
+                                and (
+                                    expected_publication is not None
+                                    or entry_record is not None
+                                )
+                            ):
+                                raise RetirementConflict(
+                                    [_retained or f"{owner}/{name}"]
+                                )
+                            _evict_index_cache(index_path)
+                            index_path.unlink()
+                            deleted = True
+                            from .retirements import finish_retirement
+                            finish_retirement(
+                                self.base_path,
+                                owner,
+                                name,
+                                publication_id=expected_publication,
+                                _lock_held=True,
+                            )
+                except RetirementRecordLockError:
+                    raise RetirementConflict([f"{owner}/{name}"])
             else:
                 _evict_index_cache(index_path)
                 index_path.unlink()
@@ -1855,9 +1926,11 @@ class DocStore:
         # like claims.
         try:
             from .retirements import (
-                finish_retirement, void_retirements_referencing,
+                void_retirement_if_stale, void_retirements_referencing,
             )
-            finish_retirement(self.base_path, owner, name)
+            void_retirement_if_stale(
+                self.base_path, owner, name, current_fingerprint=None
+            )
             void_retirements_referencing(self.base_path, f"{owner}/{name}")
         except Exception:
             pass

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -46,13 +46,14 @@ class RetirementConflict(Exception):
     its retirement was approved. Raised at the entry check (nothing touched)
     or at the final recheck after the retained-handle gate is acquired and
     immediately before the primary record would be unlinked (jdoc#89 QA-06).
-    In both cases every participating index
-    remains loadable; at worst rebuildable auxiliary artifacts of the
-    retiring handle are gone. ``changed`` lists the ``owner/name`` handles
+    In both entry and final conflicts, the retiring primary remains loadable
+    because its primary unlink did not commit; at worst rebuildable auxiliary
+    artifacts of the retiring handle are gone. A retained peer that changed or
+    disappeared is not restored. ``changed`` lists the ``owner/name`` handles
     that no longer match their proof-time fingerprints (an expected value of
-    None always conflicts; missing state never authorizes removal). Only
-    ever raised when the caller passed ``expected_fingerprints``; unguarded
-    deletes are unaffected."""
+    None always conflicts; missing state never authorizes removal). Only ever
+    raised when the caller passed ``expected_fingerprints``; unguarded deletes
+    are unaffected."""
 
     def __init__(self, changed: list):
         self.changed = list(changed)

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -1692,7 +1692,13 @@ class DocStore:
         handle still loadable when a concurrent save or direct delete changed
         either participant; auxiliary artifacts may already be gone, and a
         refresh rebuilds them. An expected value of None always conflicts.
-        Omitted → the pre-existing unguarded behavior.
+        Omitted (``None``) → the pre-existing unguarded behavior.
+
+        Passing any dict, INCLUDING an empty one, selects the guarded path and
+        therefore also requires ``retirement_publication``. An empty proof
+        asserting nothing can never authorize a removal, so it conflicts
+        rather than silently degrading to an unguarded delete. Callers that
+        want the unguarded behavior omit the argument.
 
         jdoc#93 QA-20: ``outcome`` is an optional caller-supplied dict that
         receives ``{"reason_code": ...}`` and, for guarded post-commit record

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -1660,8 +1660,10 @@ class DocStore:
         Omitted → the pre-existing unguarded behavior.
 
         jdoc#93 QA-20: ``outcome`` is an optional caller-supplied dict that
-        receives ``{"reason_code": ...}``. The bool return cannot distinguish
-        "no such index" from "lifecycle contention, try again", and the public
+        receives ``{"reason_code": ...}`` and, for guarded post-commit record
+        cleanup failure, additive durable cleanup state. The bool return cannot
+        distinguish "no such index" from "lifecycle contention, try again",
+        and the public
         tool rendered both as *Index not found.* — so an agent hitting a busy
         retirement concluded the index never existed and re-indexed, which is
         the duplicate-creation failure this arc exists to prevent. Out-param
@@ -1715,6 +1717,12 @@ class DocStore:
             changed = self._verify_expected_fingerprints(expected_fingerprints)
             if changed:
                 raise RetirementConflict(changed)
+            if (
+                not isinstance(retirement_publication, str)
+                or not retirement_publication
+            ):
+                raise RetirementConflict([f"{owner}/{name}"])
+        expected_publication = retirement_publication
 
         # jdoc#90 QA-17: this handle may be the RETAINED peer of a pending
         # retirement. Coordinate through the retirement record's lock BEFORE
@@ -1750,14 +1758,8 @@ class DocStore:
             retirement_record(self.base_path, owner, name)
             if guarded_retirement else None
         )
-        expected_publication = (
-            retirement_publication
-            or (entry_record or {}).get("publication_id")
-        )
         if guarded_retirement and (
             entry_record is None
-            or not isinstance(expected_publication, str)
-            or not expected_publication
             or entry_record.get("publication_id") != expected_publication
         ):
             raise RetirementConflict([f"{owner}/{name}"])
@@ -1894,7 +1896,10 @@ class DocStore:
                             _evict_index_cache(index_path)
                             index_path.unlink()
                             deleted = True
+                            if outcome is not None:
+                                outcome["_primary_unlink_committed"] = True
                             from .retirements import (
+                                _retirement_record_state,
                                 finish_retirement,
                                 mark_retirement_completion_pending,
                             )
@@ -1906,13 +1911,35 @@ class DocStore:
                                 _lock_held=True,
                             )
                             if retirement_completion_failed:
-                                mark_retirement_completion_pending(
-                                    self.base_path,
-                                    owner,
-                                    name,
-                                    publication_id=expected_publication,
-                                    _lock_held=True,
+                                marker_persisted = (
+                                    mark_retirement_completion_pending(
+                                        self.base_path,
+                                        owner,
+                                        name,
+                                        publication_id=expected_publication,
+                                        _lock_held=True,
+                                    )
                                 )
+                                record_state, durable_record = (
+                                    _retirement_record_state(
+                                        self.base_path, owner, name
+                                    )
+                                )
+                                if outcome is not None:
+                                    outcome["retirement_cleanup_pending"] = (
+                                        record_state != "absent"
+                                    )
+                                    outcome[
+                                        "retirement_completion_marker_persisted"
+                                    ] = marker_persisted
+                                    outcome["retirement_cleanup_record_state"] = (
+                                        record_state
+                                    )
+                                    outcome["retirement_cleanup_owned"] = (
+                                        durable_record is not None
+                                        and durable_record.get("publication_id")
+                                        == expected_publication
+                                    )
                 except RetirementRecordLockError:
                     raise RetirementConflict([f"{owner}/{name}"])
             else:
@@ -1940,8 +1967,6 @@ class DocStore:
             )
         except Exception:
             pass
-        if retirement_completion_failed:
-            return False
         _out(
             DELETE_REASON_CODES["deleted"]
             if deleted

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -1638,12 +1638,15 @@ class DocStore:
         The retirement precondition token (jdoc#88 QA-01): captured at proof
         time and re-verified inside :meth:`delete_index`, it detects ANY
         change to the stored index — content, certification, or metadata —
-        between approval and physical removal."""
+        between approval and physical removal.
+
+        Shares :func:`retirements.fingerprint_index_file` with the record-side
+        re-proof: two implementations that drifted by a byte would make every
+        publication refuse itself."""
+        from .retirements import fingerprint_index_file
         try:
-            return hashlib.sha256(
-                self._index_path(owner, name).read_bytes()
-            ).hexdigest()
-        except (OSError, ValueError):
+            return fingerprint_index_file(self._index_path(owner, name))
+        except ValueError:
             return None
 
     def _verify_expected_fingerprints(self, expected_fingerprints: dict) -> list:

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -1697,7 +1697,8 @@ class DocStore:
             _out("index_not_found")
             return False
 
-        if expected_fingerprints:
+        guarded_retirement = expected_fingerprints is not None
+        if guarded_retirement:
             changed = self._verify_expected_fingerprints(expected_fingerprints)
             if changed:
                 raise RetirementConflict(changed)
@@ -1713,7 +1714,6 @@ class DocStore:
         # interleaving can end with both participating indexes absent.
         from .retirements import (
             hold_record_lock,
-            pending_retirement,
             retirement_record,
             RetirementRecordLockError,
             try_void_retirements_referencing,
@@ -1735,11 +1735,17 @@ class DocStore:
         # completed retirement against a vanished peer.
         entry_record = (
             retirement_record(self.base_path, owner, name)
-            if expected_fingerprints else None
+            if guarded_retirement else None
         )
-        if retirement_publication is not None and (
+        expected_publication = (
+            retirement_publication
+            or (entry_record or {}).get("publication_id")
+        )
+        if guarded_retirement and (
             entry_record is None
-            or entry_record.get("publication_id") != retirement_publication
+            or not isinstance(expected_publication, str)
+            or not expected_publication
+            or entry_record.get("publication_id") != expected_publication
         ):
             raise RetirementConflict([f"{owner}/{name}"])
 
@@ -1751,6 +1757,7 @@ class DocStore:
         # previous order unlinked the primary first, so a mid-cleanup failure
         # left an un-loadable, un-retryable half-deleted index.
         deleted = False
+        retirement_completion_failed = False
         if content_dir.exists():
             shutil.rmtree(content_dir)
             deleted = True
@@ -1803,7 +1810,7 @@ class DocStore:
         # jdoc#88 QA-02: primary record removed LAST — once this succeeds the
         # index is gone; until then a failed earlier step leaves it loadable.
         if index_path.exists():
-            if expected_fingerprints:
+            if guarded_retirement:
                 # jdoc#89 QA-06 / jdoc#90 QA-17: the final gate. Everything
                 # inside the record lock is ONE destructive step: re-verify
                 # every proof-time fingerprint, require the durable record
@@ -1824,31 +1831,14 @@ class DocStore:
                         current_record = retirement_record(
                             self.base_path, owner, name
                         )
-                        expected_publication = (
-                            retirement_publication
-                            or (entry_record or {}).get("publication_id")
-                        )
                         if (
-                            expected_publication is not None
-                            and (
-                                current_record is None
-                                or current_record.get("publication_id")
-                                != expected_publication
-                            )
+                            current_record is None
+                            or current_record.get("publication_id")
+                            != expected_publication
                         ):
                             raise RetirementConflict(
                                 [
                                     (entry_record or {}).get("retained")
-                                    or f"{owner}/{name}"
-                                ]
-                            )
-                        if (
-                            entry_record is not None
-                            and current_record is None
-                        ):
-                            raise RetirementConflict(
-                                [
-                                    entry_record.get("retained")
                                     or f"{owner}/{name}"
                                 ]
                             )
@@ -1878,12 +1868,9 @@ class DocStore:
                             if changed:
                                 raise RetirementConflict(changed)
                             if (
-                                expected_publication is not None
-                                and (
-                                    current_record is None
-                                    or current_record.get("publication_id")
-                                    != expected_publication
-                                )
+                                current_record is None
+                                or current_record.get("publication_id")
+                                != expected_publication
                             ):
                                 raise RetirementConflict(
                                     [
@@ -1891,27 +1878,28 @@ class DocStore:
                                         or f"{owner}/{name}"
                                     ]
                                 )
-                            if (
-                                current_record is None
-                                and (
-                                    expected_publication is not None
-                                    or entry_record is not None
-                                )
-                            ):
-                                raise RetirementConflict(
-                                    [_retained or f"{owner}/{name}"]
-                                )
                             _evict_index_cache(index_path)
                             index_path.unlink()
                             deleted = True
-                            from .retirements import finish_retirement
-                            finish_retirement(
+                            from .retirements import (
+                                finish_retirement,
+                                mark_retirement_completion_pending,
+                            )
+                            retirement_completion_failed = not finish_retirement(
                                 self.base_path,
                                 owner,
                                 name,
                                 publication_id=expected_publication,
                                 _lock_held=True,
                             )
+                            if retirement_completion_failed:
+                                mark_retirement_completion_pending(
+                                    self.base_path,
+                                    owner,
+                                    name,
+                                    publication_id=expected_publication,
+                                    _lock_held=True,
+                                )
                 except RetirementRecordLockError:
                     raise RetirementConflict([f"{owner}/{name}"])
             else:
@@ -1930,12 +1918,17 @@ class DocStore:
             from .retirements import (
                 void_retirement_if_stale, void_retirements_referencing,
             )
-            void_retirement_if_stale(
-                self.base_path, owner, name, current_fingerprint=None
+            if not retirement_completion_failed:
+                void_retirement_if_stale(
+                    self.base_path, owner, name, current_fingerprint=None
+                )
+            void_retirements_referencing(
+                self.base_path, f"{owner}/{name}"
             )
-            void_retirements_referencing(self.base_path, f"{owner}/{name}")
         except Exception:
             pass
+        if retirement_completion_failed:
+            return False
         _out("index_deleted" if deleted else "index_not_found")
         return deleted
 

--- a/src/jdocmunch_mcp/storage/doc_store.py
+++ b/src/jdocmunch_mcp/storage/doc_store.py
@@ -1669,7 +1669,7 @@ class DocStore:
         entry_record: Optional[dict],
         outcome: Optional[dict],
     ) -> bool:
-        """The final authorization gate — the ONE destructive step.
+        """The final authorization gate: the ONE destructive step.
 
         jdoc#89 QA-06 / jdoc#90 QA-17 / jdoc#93 QA-19. Called holding this
         handle's write lock, with every auxiliary artifact already removed and
@@ -1679,15 +1679,15 @@ class DocStore:
 
         Everything before the retained gate is fast rejection only. A
         fingerprint read before that gate cannot see a writer already in
-        flight on the retained handle — one that passed its own void scan
+        flight on the retained handle: one that passed its own void scan
         before our record existed, or a save paused an instruction short of
         ``_atomic_replace``. Both hold the retained handle's write lock, so
         only the proof repeated AFTER the gate closes can authorize the
         commit.
 
         Returns True when exact-publication record completion also succeeded,
-        False when the primary unlink committed but that completion did not —
-        the caller must then leave the durable record alone as recoverable
+        False when the primary unlink committed but that completion did not.
+        The caller must then leave the durable record alone as recoverable
         state. Raises :class:`RetirementConflict` on any refusal, always
         before the unlink, so the retiring monolith stays loadable; only
         rebuildable auxiliary artifacts may already be gone.
@@ -1756,7 +1756,7 @@ class DocStore:
 
                     # Past this point the retirement HAS committed. Add no
                     # durable write to a critical section that still holds
-                    # both the record lock and the retained gate — a failed
+                    # both the record lock and the retained gate. A failed
                     # completion is already evidence the store is unhealthy.
                     # Read the durable state, disclose it, and get out.
                     if finish_retirement(

--- a/src/jdocmunch_mcp/storage/retirements.py
+++ b/src/jdocmunch_mcp/storage/retirements.py
@@ -39,6 +39,7 @@ import hashlib
 import itertools
 import json
 import os
+import re
 import secrets
 import threading
 import time
@@ -92,17 +93,31 @@ def fingerprint_index_file(index_path) -> Optional[str]:
         return None
 
 
+_SAFE_COMPONENT_RE = re.compile(r"[A-Za-z0-9._-]+")
+
+
+def is_safe_path_component(value) -> bool:
+    """Whether ``value`` may be joined into a store path as one component.
+
+    The single definition of the rule, shared with
+    ``DocStore._safe_repo_component``. A hand-rolled second rule is how
+    ``C:..`` slipped through: it contains no separator and is neither ``.``
+    nor ``..``, but Windows treats it as drive-relative, so joining it walks
+    out of the store. Allowing only ``[A-Za-z0-9._-]`` rejects drive letters,
+    separators, and traversal alike, without enumerating platform syntax.
+    """
+    return (
+        isinstance(value, str)
+        and value not in {".", ".."}
+        and _SAFE_COMPONENT_RE.fullmatch(value) is not None
+    )
+
+
 def _fingerprint_handle(base_path, handle: str) -> Optional[str]:
     if not isinstance(handle, str) or "/" not in handle:
         return None
     owner, _, name = handle.partition("/")
-    # A handle reaches the path join only as two ordinary directory-level
-    # names. Anything that could traverse out of the store fails closed here
-    # rather than being hashed from wherever it pointed.
-    if not all(
-        part and part not in {".", ".."} and not set(part) & {"/", "\\"}
-        for part in (owner, name)
-    ):
+    if not is_safe_path_component(owner) or not is_safe_path_component(name):
         return None
     return fingerprint_index_file(
         _retiring_index_path(base_path, owner, name)

--- a/src/jdocmunch_mcp/storage/retirements.py
+++ b/src/jdocmunch_mcp/storage/retirements.py
@@ -268,6 +268,22 @@ def retirement_record(base_path, owner: str, name: str) -> Optional[dict]:
     return _read_record(_record_path(base_path, owner, name))
 
 
+def _retirement_record_state(
+    base_path, owner: str, name: str
+) -> tuple[str, Optional[dict]]:
+    """Return the durable slot state without treating unreadable as absent."""
+    path = _record_path(base_path, owner, name)
+    current = _read_record(path)
+    if current is not None:
+        return "readable", current
+    try:
+        if path.is_file():
+            return "unreadable", None
+    except OSError:
+        return "unreadable", None
+    return "absent", None
+
+
 def _remove_publication_locked(
     path: Path, publication_id: Optional[str]
 ) -> bool:
@@ -478,37 +494,51 @@ def try_void_retirements_referencing(
 def pending_retirement(base_path, owner: str, name: str) -> Optional[dict]:
     """The pending record for ``owner/name``, or None.
 
-    jdoc#89 QA-08: a record whose retiring index no longer exists is a
-    COMPLETED retirement whose record finalization was interrupted — not
-    pending work. It is self-healed (best-effort unlink) and reported None,
-    so completed deletions are never claimed as pending.
+    jdoc#89 QA-08: a record whose retiring index no longer exists represents
+    cleanup after a completed retirement, not another destructive attempt.
+    It is removed and reported None when self-healing succeeds. If removal
+    fails, the durable record is returned so recovery state is not hidden.
     """
     try:
         path = _record_path(base_path, owner, name)
-        current = _read_record(path)
-        if current is None:
+        state, current = _retirement_record_state(base_path, owner, name)
+        if state == "absent":
             return None
+        if state == "unreadable":
+            return {"record_state": "unreadable"}
         if not _retiring_index_path(base_path, owner, name).is_file():
             try:
                 with hold_record_lock(
                     base_path, owner, name, blocking=False
                 ):
-                    current = _read_record(path)
-                    if current is None:
+                    state, current = _retirement_record_state(
+                        base_path, owner, name
+                    )
+                    if state == "absent":
                         return None
+                    if state == "unreadable":
+                        return {"record_state": "unreadable"}
                     if (
                         _retiring_index_path(
                             base_path, owner, name
                         ).is_file()
-                        or current.get("completion_pending") is True
                     ):
                         return current
-                    _remove_publication_locked(
+                    removed = _remove_publication_locked(
                         path, current.get("publication_id")
                     )
+                    if removed:
+                        return None
+                    state, current = _retirement_record_state(
+                        base_path, owner, name
+                    )
+                    if state == "readable":
+                        return current
+                    if state == "unreadable":
+                        return {"record_state": "unreadable"}
                     return None
             except RetirementRecordLockError:
                 return current
         return current
     except OSError:
-        return None
+        return {"record_state": "unreadable"}

--- a/src/jdocmunch_mcp/storage/retirements.py
+++ b/src/jdocmunch_mcp/storage/retirements.py
@@ -113,6 +113,60 @@ def is_safe_path_component(value) -> bool:
     )
 
 
+def _valid_retirement_pair(
+    retiring: str, retained: str, fingerprints: dict
+) -> bool:
+    """Whether one proof map describes exactly one distinct retirement pair."""
+    if (
+        not isinstance(retiring, str)
+        or not isinstance(retained, str)
+        or retiring == retained
+        or retiring.count("/") != 1
+        or retained.count("/") != 1
+    ):
+        return False
+    retiring_owner, retiring_name = retiring.split("/", 1)
+    retained_owner, retained_name = retained.split("/", 1)
+    if not all(
+        is_safe_path_component(component)
+        for component in (
+            retiring_owner,
+            retiring_name,
+            retained_owner,
+            retained_name,
+        )
+    ):
+        return False
+    if (
+        not isinstance(fingerprints, dict)
+        or set(fingerprints) != {retiring, retained}
+    ):
+        return False
+    return all(
+        isinstance(fingerprints[handle], str) and fingerprints[handle]
+        for handle in (retiring, retained)
+    )
+
+
+def _valid_retirement_record(record, owner: str, name: str) -> bool:
+    """Whether a durable record is structurally bound to its retirement slot."""
+    if (
+        not isinstance(record, dict)
+        or not is_safe_path_component(owner)
+        or not is_safe_path_component(name)
+    ):
+        return False
+    retiring = f"{owner}/{name}"
+    return (
+        record.get("retiring") == retiring
+        and _valid_retirement_pair(
+            retiring,
+            record.get("retained"),
+            record.get("fingerprints"),
+        )
+    )
+
+
 def _fingerprint_handle(base_path, handle: str) -> Optional[str]:
     if not isinstance(handle, str) or "/" not in handle:
         return None
@@ -147,11 +201,19 @@ def begin_retirement(
     """
     tmp = None
     try:
+        if (
+            not is_safe_path_component(owner)
+            or not is_safe_path_component(name)
+        ):
+            return None
+        retiring = f"{owner}/{name}"
+        if not _valid_retirement_pair(retiring, retained, fingerprints):
+            return None
         path = _record_path(base_path, owner, name)
         path.parent.mkdir(parents=True, exist_ok=True)
         publication_id = secrets.token_hex(16)
         payload = {
-            "retiring": f"{owner}/{name}",
+            "retiring": retiring,
             "retained": retained,
             "fingerprints": fingerprints,
             "family": family,

--- a/src/jdocmunch_mcp/storage/retirements.py
+++ b/src/jdocmunch_mcp/storage/retirements.py
@@ -32,9 +32,11 @@ not pending work — ``pending_retirement`` self-heals it and reports None.
 
 from __future__ import annotations
 
+import hashlib
 import itertools
 import json
 import os
+import secrets
 import threading
 import time
 from contextlib import contextmanager
@@ -59,6 +61,10 @@ _RECORDS_DIR = ".retirements"
 _tmp_counter = itertools.count()
 
 
+class RetirementRecordLockError(RuntimeError):
+    """The authoritative retirement-record lock could not be acquired."""
+
+
 def _record_path(base_path, owner: str, name: str) -> Path:
     return Path(base_path) / owner / _RECORDS_DIR / f"{name}.json"
 
@@ -68,41 +74,85 @@ def _retiring_index_path(base_path, owner: str, name: str) -> Path:
     return Path(base_path) / owner / f"{name}.json"
 
 
+def _fingerprint_handle(base_path, handle: str) -> Optional[str]:
+    if not isinstance(handle, str) or "/" not in handle:
+        return None
+    owner, _, name = handle.partition("/")
+    if not owner or not name:
+        return None
+    try:
+        return hashlib.sha256(
+            _retiring_index_path(base_path, owner, name).read_bytes()
+        ).hexdigest()
+    except OSError:
+        return None
+
+
+def _fingerprints_match(base_path, fingerprints: dict) -> bool:
+    if not isinstance(fingerprints, dict) or not fingerprints:
+        return False
+    return all(
+        isinstance(expected, str)
+        and expected
+        and _fingerprint_handle(base_path, handle) == expected
+        for handle, expected in fingerprints.items()
+    )
+
+
 def begin_retirement(
     base_path, owner: str, name: str, *,
     retained: str, fingerprints: dict, family: str,
-) -> bool:
+) -> Optional[str]:
     """Durably publish the record for ``owner/name`` being retired.
 
-    Returns True only when the record is fsync'd and atomically in place —
-    the publication receipt every retirement path must require before its
-    destructive step (jdoc#89 QA-07). False means nothing may be removed.
+    Returns a stable internal publication identity only when the record is
+    fsync'd, atomically in place, and re-read under its authoritative lock.
+    ``None`` means nothing may be removed.
     """
+    tmp = None
     try:
         path = _record_path(base_path, owner, name)
         path.parent.mkdir(parents=True, exist_ok=True)
+        publication_id = secrets.token_hex(16)
         payload = {
             "retiring": f"{owner}/{name}",
             "retained": retained,
             "fingerprints": fingerprints,
             "family": family,
             "started_at": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
+            "publication_id": publication_id,
         }
-        tmp = path.with_name(
-            f"{path.name}.{os.getpid()}.{threading.get_ident()}."
-            f"{next(_tmp_counter)}.tmp"
-        )
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(payload, f, separators=(",", ":"))
-            f.flush()
-            # jdoc#89 QA-11: the receipt promises the record survives sudden
-            # power loss, so flush the bytes before the atomic replace.
-            os.fsync(f.fileno())
-        os.replace(tmp, path)
-        _fsync_dir(path.parent)
-        return True
-    except OSError:
-        return False
+        with hold_record_lock(base_path, owner, name):
+            # QA-19 publication authority starts only after the proof is
+            # repeated under the slot lock. A publisher that waited behind a
+            # completed retirement or concurrent replacement cannot publish
+            # stale fingerprints into the newly available slot.
+            if not _fingerprints_match(base_path, fingerprints):
+                return None
+            tmp = path.with_name(
+                f"{path.name}.{os.getpid()}.{threading.get_ident()}."
+                f"{next(_tmp_counter)}.tmp"
+            )
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(payload, f, separators=(",", ":"))
+                f.flush()
+                # jdoc#89 QA-11: the receipt promises the record survives
+                # sudden power loss, so flush the bytes before replacement.
+                os.fsync(f.fileno())
+            os.replace(tmp, path)
+            tmp = None
+            _fsync_dir(path.parent)
+            current = _read_record(path)
+            if current is None or current.get("publication_id") != publication_id:
+                return None
+        return publication_id
+    except (OSError, RetirementRecordLockError):
+        if tmp is not None:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+        return None
 
 
 def _fsync_dir(directory: Path) -> None:
@@ -182,7 +232,7 @@ def _release_fd(fd: int) -> None:
 
 
 @contextmanager
-def hold_record_lock(base_path, owner: str, name: str):
+def hold_record_lock(base_path, owner: str, name: str, *, blocking: bool = True):
     """Exclusive cross-process lock on ``owner/name``'s retirement record.
 
     jdoc#90 QA-17: the record is the PAIR coordination point. The guarded
@@ -192,22 +242,94 @@ def hold_record_lock(base_path, owner: str, name: str):
     lock (bounded, non-blocking — see ``try_void_retirements_referencing``)
     instead of taking a second handle lock. No caller ever blocks on two
     locks, so the QA-14 cross-handle deadlock surface stays closed."""
-    fd = _acquire_fd(_lock_path(base_path, owner, name), blocking=True)
+    fd = _acquire_fd(_lock_path(base_path, owner, name), blocking=blocking)
+    if fd is None:
+        raise RetirementRecordLockError(
+            f"retirement record lock unavailable for {owner}/{name}"
+        )
     try:
         yield
     finally:
-        if fd is not None:
-            _release_fd(fd)
+        _release_fd(fd)
 
 
-def finish_retirement(base_path, owner: str, name: str) -> None:
-    """Remove the record: retirement completed or was voided by conflict."""
+def _read_record(path: Path) -> Optional[dict]:
     try:
-        path = _record_path(base_path, owner, name)
-        if path.exists():
-            path.unlink()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def retirement_record(base_path, owner: str, name: str) -> Optional[dict]:
+    """Read the current publication without mutating the retirement slot."""
+    return _read_record(_record_path(base_path, owner, name))
+
+
+def _remove_publication_locked(
+    path: Path, publication_id: Optional[str]
+) -> bool:
+    current = _read_record(path)
+    if current is None:
+        return False
+    current_id = current.get("publication_id")
+    if publication_id is None:
+        # Load-compatible cleanup for pre-QA-19 records only. A current record
+        # with stable identity is never removable by unscoped old code.
+        if current_id is not None:
+            return False
+    elif current_id != publication_id:
+        return False
+    try:
+        path.unlink()
+        return True
     except OSError:
-        pass
+        return False
+
+
+def finish_retirement(
+    base_path,
+    owner: str,
+    name: str,
+    *,
+    publication_id: Optional[str] = None,
+    _lock_held: bool = False,
+) -> bool:
+    """Remove only the exact publication completed or voided by its caller."""
+    path = _record_path(base_path, owner, name)
+    if _lock_held:
+        return _remove_publication_locked(path, publication_id)
+    try:
+        with hold_record_lock(base_path, owner, name):
+            return _remove_publication_locked(path, publication_id)
+    except RetirementRecordLockError:
+        return False
+
+
+def void_retirement_if_stale(
+    base_path, owner: str, name: str, current_fingerprint: Optional[str]
+) -> bool:
+    """Remove a current retiring-side publication only when its proof is stale."""
+    path = _record_path(base_path, owner, name)
+    if not path.is_file():
+        return False
+    try:
+        with hold_record_lock(base_path, owner, name, blocking=False):
+            current = _read_record(path)
+            if current is None:
+                return False
+            handle = f"{owner}/{name}"
+            if (
+                current_fingerprint is not None
+                and (current.get("fingerprints") or {}).get(handle)
+                == current_fingerprint
+            ):
+                return False
+            return _remove_publication_locked(
+                path, current.get("publication_id")
+            )
+    except RetirementRecordLockError:
+        return False
 
 
 def _records_referencing(base_path, handle: str):
@@ -226,7 +348,9 @@ def _records_referencing(base_path, handle: str):
     return hits
 
 
-def void_retirements_referencing(base_path, handle: str) -> None:
+def void_retirements_referencing(
+    base_path, handle: str, current_fingerprint: Optional[str] = None
+) -> None:
     """Void every pending record whose RETAINED side is ``handle``.
 
     jdoc#89 QA-09/QA-10: once the retained peer is rewritten or directly
@@ -244,9 +368,17 @@ def void_retirements_referencing(base_path, handle: str) -> None:
         if fd is None:
             continue  # mid-destructive-step — its own gate coordinates
         try:
-            record.unlink()
-        except OSError:
-            pass
+            current = _read_record(record)
+            if current is not None and current.get("retained") == handle:
+                if (
+                    current_fingerprint is not None
+                    and (current.get("fingerprints") or {}).get(handle)
+                    == current_fingerprint
+                ):
+                    continue
+                _remove_publication_locked(
+                    record, current.get("publication_id")
+                )
         finally:
             _release_fd(fd)
 
@@ -278,10 +410,11 @@ def try_void_retirements_referencing(
                     return False
                 time.sleep(0.01)
         try:
-            try:
-                record.unlink()
-            except OSError:
-                pass
+            current = _read_record(record)
+            if current is not None and current.get("retained") == handle:
+                _remove_publication_locked(
+                    record, current.get("publication_id")
+                )
         finally:
             _release_fd(fd)
     return True
@@ -297,14 +430,27 @@ def pending_retirement(base_path, owner: str, name: str) -> Optional[dict]:
     """
     try:
         path = _record_path(base_path, owner, name)
-        if not path.is_file():
+        current = _read_record(path)
+        if current is None:
             return None
         if not _retiring_index_path(base_path, owner, name).is_file():
             try:
-                path.unlink()
-            except OSError:
-                pass
-            return None
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
+                with hold_record_lock(
+                    base_path, owner, name, blocking=False
+                ):
+                    current = _read_record(path)
+                    if current is None:
+                        return None
+                    if _retiring_index_path(
+                        base_path, owner, name
+                    ).is_file():
+                        return current
+                    _remove_publication_locked(
+                        path, current.get("publication_id")
+                    )
+                    return None
+            except RetirementRecordLockError:
+                return current
+        return current
+    except OSError:
         return None

--- a/src/jdocmunch_mcp/storage/retirements.py
+++ b/src/jdocmunch_mcp/storage/retirements.py
@@ -25,9 +25,11 @@ Durability (jdoc#89 QA-11): the record is fsync'd before the atomic replace
 (and the directory entry flushed where the platform supports it), so a
 returned receipt survives sudden power loss.
 
-Truthfulness (jdoc#89 QA-08): a record whose retiring index no longer
-exists describes a COMPLETED retirement whose finalization was interrupted,
-not pending work — ``pending_retirement`` self-heals it and reports None.
+Truthfulness (jdoc#89 QA-08): an unmarked record whose retiring index no
+longer exists describes a completed retirement whose finalization was
+interrupted, so ``pending_retirement`` self-heals it and reports None. A
+publication whose completion unlink explicitly failed is marked before the
+record lock is released and remains pending even though its primary is gone.
 """
 
 from __future__ import annotations
@@ -306,6 +308,59 @@ def finish_retirement(
         return False
 
 
+def mark_retirement_completion_pending(
+    base_path,
+    owner: str,
+    name: str,
+    *,
+    publication_id: str,
+    _lock_held: bool = False,
+) -> bool:
+    """Durably mark the exact publication whose final unlink failed."""
+    path = _record_path(base_path, owner, name)
+
+    def _mark_locked() -> bool:
+        current = _read_record(path)
+        if (
+            current is None
+            or current.get("publication_id") != publication_id
+        ):
+            return False
+        payload = dict(current)
+        payload["completion_pending"] = True
+        tmp = path.with_name(
+            f"{path.name}.{os.getpid()}.{threading.get_ident()}."
+            f"{next(_tmp_counter)}.tmp"
+        )
+        try:
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(payload, f, separators=(",", ":"))
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, path)
+            _fsync_dir(path.parent)
+            marked = _read_record(path)
+            return (
+                marked is not None
+                and marked.get("publication_id") == publication_id
+                and marked.get("completion_pending") is True
+            )
+        except OSError:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            return False
+
+    if _lock_held:
+        return _mark_locked()
+    try:
+        with hold_record_lock(base_path, owner, name):
+            return _mark_locked()
+    except RetirementRecordLockError:
+        return False
+
+
 def void_retirement_if_stale(
     base_path, owner: str, name: str, current_fingerprint: Optional[str]
 ) -> bool:
@@ -441,9 +496,12 @@ def pending_retirement(base_path, owner: str, name: str) -> Optional[dict]:
                     current = _read_record(path)
                     if current is None:
                         return None
-                    if _retiring_index_path(
-                        base_path, owner, name
-                    ).is_file():
+                    if (
+                        _retiring_index_path(
+                            base_path, owner, name
+                        ).is_file()
+                        or current.get("completion_pending") is True
+                    ):
                         return current
                     _remove_publication_locked(
                         path, current.get("publication_id")

--- a/src/jdocmunch_mcp/storage/retirements.py
+++ b/src/jdocmunch_mcp/storage/retirements.py
@@ -25,11 +25,12 @@ Durability (jdoc#89 QA-11): the record is fsync'd before the atomic replace
 (and the directory entry flushed where the platform supports it), so a
 returned receipt survives sudden power loss.
 
-Truthfulness (jdoc#89 QA-08): an unmarked record whose retiring index no
-longer exists describes a completed retirement whose finalization was
-interrupted, so ``pending_retirement`` self-heals it and reports None. A
-publication whose completion unlink explicitly failed is marked before the
-record lock is released and remains pending even though its primary is gone.
+Truthfulness (jdoc#89 QA-08): a record whose retiring index no longer exists
+describes a COMPLETED retirement whose finalization was interrupted, not
+pending work — ``pending_retirement`` self-heals it under the record lock and
+reports None. When that self-heal cannot remove the record, the durable
+record is returned instead, so cleanup state that needs recovery is disclosed
+rather than hidden behind a false "nothing pending".
 """
 
 from __future__ import annotations
@@ -320,59 +321,6 @@ def finish_retirement(
     try:
         with hold_record_lock(base_path, owner, name):
             return _remove_publication_locked(path, publication_id)
-    except RetirementRecordLockError:
-        return False
-
-
-def mark_retirement_completion_pending(
-    base_path,
-    owner: str,
-    name: str,
-    *,
-    publication_id: str,
-    _lock_held: bool = False,
-) -> bool:
-    """Durably mark the exact publication whose final unlink failed."""
-    path = _record_path(base_path, owner, name)
-
-    def _mark_locked() -> bool:
-        current = _read_record(path)
-        if (
-            current is None
-            or current.get("publication_id") != publication_id
-        ):
-            return False
-        payload = dict(current)
-        payload["completion_pending"] = True
-        tmp = path.with_name(
-            f"{path.name}.{os.getpid()}.{threading.get_ident()}."
-            f"{next(_tmp_counter)}.tmp"
-        )
-        try:
-            with open(tmp, "w", encoding="utf-8") as f:
-                json.dump(payload, f, separators=(",", ":"))
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp, path)
-            _fsync_dir(path.parent)
-            marked = _read_record(path)
-            return (
-                marked is not None
-                and marked.get("publication_id") == publication_id
-                and marked.get("completion_pending") is True
-            )
-        except OSError:
-            try:
-                tmp.unlink()
-            except OSError:
-                pass
-            return False
-
-    if _lock_held:
-        return _mark_locked()
-    try:
-        with hold_record_lock(base_path, owner, name):
-            return _mark_locked()
     except RetirementRecordLockError:
         return False
 

--- a/src/jdocmunch_mcp/storage/retirements.py
+++ b/src/jdocmunch_mcp/storage/retirements.py
@@ -77,18 +77,36 @@ def _retiring_index_path(base_path, owner: str, name: str) -> Path:
     return Path(base_path) / owner / f"{name}.json"
 
 
+def fingerprint_index_file(index_path) -> Optional[str]:
+    """sha256 of a stored monolith's bytes, or None when unreadable.
+
+    The ONE definition of the retirement precondition token (jdoc#88 QA-01).
+    ``DocStore.index_fingerprint`` captures it at proof time and this module
+    re-proves it under the record lock, so the two must agree byte for byte —
+    any divergence would make ``begin_retirement`` refuse every publication.
+    They share this implementation rather than keeping two copies in step.
+    """
+    try:
+        return hashlib.sha256(Path(index_path).read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
 def _fingerprint_handle(base_path, handle: str) -> Optional[str]:
     if not isinstance(handle, str) or "/" not in handle:
         return None
     owner, _, name = handle.partition("/")
-    if not owner or not name:
+    # A handle reaches the path join only as two ordinary directory-level
+    # names. Anything that could traverse out of the store fails closed here
+    # rather than being hashed from wherever it pointed.
+    if not all(
+        part and part not in {".", ".."} and not set(part) & {"/", "\\"}
+        for part in (owner, name)
+    ):
         return None
-    try:
-        return hashlib.sha256(
-            _retiring_index_path(base_path, owner, name).read_bytes()
-        ).hexdigest()
-    except OSError:
-        return None
+    return fingerprint_index_file(
+        _retiring_index_path(base_path, owner, name)
+    )
 
 
 def _fingerprints_match(base_path, fingerprints: dict) -> bool:

--- a/src/jdocmunch_mcp/storage/retirements.py
+++ b/src/jdocmunch_mcp/storage/retirements.py
@@ -27,8 +27,8 @@ returned receipt survives sudden power loss.
 
 Truthfulness (jdoc#89 QA-08): a record whose retiring index no longer exists
 describes a COMPLETED retirement whose finalization was interrupted, not
-pending work — ``pending_retirement`` self-heals it under the record lock and
-reports None. When that self-heal cannot remove the record, the durable
+pending work. ``pending_retirement`` self-heals it under the record lock
+and reports None. When that self-heal cannot remove the record, the durable
 record is returned instead, so cleanup state that needs recovery is disclosed
 rather than hidden behind a false "nothing pending".
 """
@@ -83,7 +83,7 @@ def fingerprint_index_file(index_path) -> Optional[str]:
 
     The ONE definition of the retirement precondition token (jdoc#88 QA-01).
     ``DocStore.index_fingerprint`` captures it at proof time and this module
-    re-proves it under the record lock, so the two must agree byte for byte —
+    re-proves it under the record lock, so the two must agree byte for byte;
     any divergence would make ``begin_retirement`` refuse every publication.
     They share this implementation rather than keeping two copies in step.
     """

--- a/src/jdocmunch_mcp/storage/retirements.py
+++ b/src/jdocmunch_mcp/storage/retirements.py
@@ -57,6 +57,7 @@ except ImportError:  # POSIX
     msvcrt = None
 
 _RECORDS_DIR = ".retirements"
+_POSIX_DIRECTORY_FSYNC = os.name != "nt"
 
 # jdoc#89 QA-07: a PID-only temp suffix let two same-process publishers
 # collide on one temporary path (one replace then fails with
@@ -254,16 +255,12 @@ def begin_retirement(
 
 
 def _fsync_dir(directory: Path) -> None:
-    """Flush the directory entry after ``os.replace`` (POSIX; Windows has no
-    directory fsync — NTFS journals the rename). Best-effort."""
-    try:
-        fd = os.open(str(directory), os.O_RDONLY)
-    except OSError:
+    """Flush the directory entry after ``os.replace`` on POSIX."""
+    if not _POSIX_DIRECTORY_FSYNC:
         return
+    fd = os.open(str(directory), os.O_RDONLY)
     try:
         os.fsync(fd)
-    except OSError:
-        pass
     finally:
         os.close(fd)
 
@@ -310,7 +307,10 @@ def _acquire_fd(lock_path: Path, blocking: bool) -> Optional[int]:
                             time.sleep(0.05)
                 msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
                 return fd
-            return fd  # no lock primitive — degrade like the index lock
+            # Guarded retirement is unsupported without a real cross-process
+            # lock primitive. An open descriptor alone is not authority.
+            os.close(fd)
+            return None
         except OSError:
             os.close(fd)
             return None

--- a/src/jdocmunch_mcp/tools/delete_index.py
+++ b/src/jdocmunch_mcp/tools/delete_index.py
@@ -10,7 +10,23 @@ from ..storage import DocStore
 # both arrived as success:false, "Index not found.", so a caller that hit a
 # retirement mid-flight concluded the index never existed and re-indexed. That
 # duplicate creation is the exact failure this arc exists to prevent.
-_RETRYABLE_REASONS = frozenset({"index_lifecycle_busy"})
+DELETE_RESULT_VOCABULARY = {
+    "index_deleted": {
+        "outcome": "Deleted",
+        "success": True,
+        "retryable": False,
+    },
+    "index_not_found": {
+        "outcome": "Missing",
+        "success": False,
+        "retryable": False,
+    },
+    "index_lifecycle_busy": {
+        "outcome": "Lifecycle contention",
+        "success": False,
+        "retryable": True,
+    },
+}
 
 _MESSAGES = {
     "index_deleted": "Index deleted.",
@@ -40,11 +56,18 @@ def delete_index(repo: str, storage_path: Optional[str] = None) -> dict:
     reason_code = outcome.get(
         "reason_code", "index_deleted" if deleted else "index_not_found"
     )
+    result_contract = DELETE_RESULT_VOCABULARY.get(reason_code)
     return {
-        "success": deleted,
+        "success": (
+            result_contract["success"] if result_contract is not None else deleted
+        ),
         "repo": f"{owner}/{name}",
         "reason_code": reason_code,
-        "retryable": reason_code in _RETRYABLE_REASONS,
+        "retryable": (
+            result_contract["retryable"]
+            if result_contract is not None
+            else False
+        ),
         "message": _MESSAGES.get(
             reason_code, "Index deleted." if deleted else "Index not found."
         ),

--- a/src/jdocmunch_mcp/tools/delete_index.py
+++ b/src/jdocmunch_mcp/tools/delete_index.py
@@ -4,6 +4,11 @@ import time
 from typing import Optional
 
 from ..storage import DocStore
+from ..storage.doc_store import DELETE_REASON_CODES
+
+_DELETED = DELETE_REASON_CODES["deleted"]
+_NOT_FOUND = DELETE_REASON_CODES["not_found"]
+_LIFECYCLE_BUSY = DELETE_REASON_CODES["lifecycle_busy"]
 
 # jdoc#93 QA-20: published outcome vocabulary. `success` alone cannot tell an
 # agent whether to retry — lifecycle contention and a genuinely missing index
@@ -11,17 +16,17 @@ from ..storage import DocStore
 # retirement mid-flight concluded the index never existed and re-indexed. That
 # duplicate creation is the exact failure this arc exists to prevent.
 DELETE_RESULT_VOCABULARY = {
-    "index_deleted": {
+    _DELETED: {
         "outcome": "Deleted",
         "success": True,
         "retryable": False,
     },
-    "index_not_found": {
+    _NOT_FOUND: {
         "outcome": "Missing",
         "success": False,
         "retryable": False,
     },
-    "index_lifecycle_busy": {
+    _LIFECYCLE_BUSY: {
         "outcome": "Lifecycle contention",
         "success": False,
         "retryable": True,
@@ -29,9 +34,9 @@ DELETE_RESULT_VOCABULARY = {
 }
 
 _MESSAGES = {
-    "index_deleted": "Index deleted.",
-    "index_not_found": "Index not found.",
-    "index_lifecycle_busy": (
+    _DELETED: "Index deleted.",
+    _NOT_FOUND: "Index not found.",
+    _LIFECYCLE_BUSY: (
         "Index is busy completing a retirement. The index still exists; "
         "retry shortly."
     ),
@@ -53,9 +58,8 @@ def delete_index(repo: str, storage_path: Optional[str] = None) -> dict:
     latency_ms = int((time.perf_counter() - t0) * 1000)
     # Fall back rather than assume: a store that ignored `outcome` still
     # yields a truthful code from the boolean it did return.
-    reason_code = outcome.get(
-        "reason_code", "index_deleted" if deleted else "index_not_found"
-    )
+    fallback_reason = _DELETED if deleted else _NOT_FOUND
+    reason_code = outcome.get("reason_code", fallback_reason)
     result_contract = DELETE_RESULT_VOCABULARY.get(reason_code)
     return {
         "success": (
@@ -68,8 +72,6 @@ def delete_index(repo: str, storage_path: Optional[str] = None) -> dict:
             if result_contract is not None
             else False
         ),
-        "message": _MESSAGES.get(
-            reason_code, "Index deleted." if deleted else "Index not found."
-        ),
+        "message": _MESSAGES.get(reason_code, _MESSAGES[fallback_reason]),
         "_meta": {"latency_ms": latency_ms},
     }

--- a/src/jdocmunch_mcp/tools/index_local.py
+++ b/src/jdocmunch_mcp/tools/index_local.py
@@ -190,8 +190,9 @@ def _execute_retirement(store, owner, repo_name, repo_id, target, family,
     ``"record_unavailable"`` (record publication failed; nothing destructive
     was attempted); ``"cleanup_incomplete"`` (``info`` carries
     ``pending_retirement: True`` only when the durable record actually
-    exists — QA-07 truthfulness). Every non-``retired`` outcome leaves both
-    handles loadable."""
+    exists; QA-07 truthfulness). A completion failure after the primary
+    unlink leaves the retiring handle absent and its exact publication
+    pending; other non-``retired`` outcomes leave both handles loadable."""
     from ..storage.doc_store import RetirementConflict
     from ..storage.retirements import (
         begin_retirement,
@@ -247,12 +248,6 @@ def _execute_retirement(store, owner, repo_name, repo_id, target, family,
         if pending_retirement(store.base_path, owner, repo_name) is not None:
             info["pending_retirement"] = True
         return "cleanup_incomplete", info
-    finish_retirement(
-        store.base_path,
-        owner,
-        repo_name,
-        publication_id=publication_id,
-    )
     return "retired", {}
 
 

--- a/src/jdocmunch_mcp/tools/index_local.py
+++ b/src/jdocmunch_mcp/tools/index_local.py
@@ -179,9 +179,10 @@ def _execute_retirement(store, owner, repo_name, repo_id, target, family,
       3. Publish the durable retiring record and REQUIRE the receipt:
          cleanup never starts without authoritative recovery state on disk
          (QA-07).
-      4. Guarded delete: ``delete_index`` re-verifies the fingerprints
-         inside the deletion boundary at entry AND again immediately before
-         the primary record is removed, under the handle's write lock.
+      4. Guarded delete: ``delete_index`` re-verifies the exact publication
+         and fingerprints after nonblocking retained-handle coordination,
+         then holds those authorities through primary removal and conditional
+         completion.
 
     Returns ``(outcome, info)``. Outcomes: ``"retired"``; ``"conflict"``
     (an index changed or vanished — ``info`` may carry ``changed_handles``);
@@ -214,11 +215,11 @@ def _execute_retirement(store, owner, repo_name, repo_id, target, family,
         ]}
     if not reverify(sel, peer):
         return "unproven", {}
-    published = begin_retirement(
+    publication_id = begin_retirement(
         store.base_path, owner, repo_name,
         retained=target, fingerprints=fingerprints, family=family,
     )
-    if not published:
+    if not publication_id:
         return "record_unavailable", {}
     try:
         # jdoc#93 QA-23: this is the INTERNAL coordinated operation, already
@@ -229,9 +230,15 @@ def _execute_retirement(store, owner, repo_name, repo_id, target, family,
         removed = store.delete_index(
             owner, repo_name, expected_fingerprints=fingerprints,
             lock_wait=True,
+            retirement_publication=publication_id,
         )
     except RetirementConflict as conflict:
-        finish_retirement(store.base_path, owner, repo_name)  # voided
+        finish_retirement(
+            store.base_path,
+            owner,
+            repo_name,
+            publication_id=publication_id,
+        )
         return "conflict", {"changed_handles": conflict.changed}
     except Exception:
         removed = False
@@ -240,7 +247,12 @@ def _execute_retirement(store, owner, repo_name, repo_id, target, family,
         if pending_retirement(store.base_path, owner, repo_name) is not None:
             info["pending_retirement"] = True
         return "cleanup_incomplete", info
-    finish_retirement(store.base_path, owner, repo_name)
+    finish_retirement(
+        store.base_path,
+        owner,
+        repo_name,
+        publication_id=publication_id,
+    )
     return "retired", {}
 
 

--- a/src/jdocmunch_mcp/tools/index_local.py
+++ b/src/jdocmunch_mcp/tools/index_local.py
@@ -247,7 +247,7 @@ def _execute_retirement(store, owner, repo_name, repo_id, target, family,
                 store.base_path, owner, repo_name
             )
             if pending is not None:
-                info["retirement_cleanup_pending"] = True
+                info["pending_retirement"] = True
         return "conflict", info
     except Exception:
         removed = bool(delete_outcome.get("_primary_unlink_committed"))

--- a/src/jdocmunch_mcp/tools/index_local.py
+++ b/src/jdocmunch_mcp/tools/index_local.py
@@ -188,11 +188,10 @@ def _execute_retirement(store, owner, repo_name, repo_id, target, family,
     (an index changed or vanished — ``info`` may carry ``changed_handles``);
     ``"unproven"`` (the reloaded state no longer satisfies the proof);
     ``"record_unavailable"`` (record publication failed; nothing destructive
-    was attempted); ``"cleanup_incomplete"`` (``info`` carries
-    ``pending_retirement: True`` only when the durable record actually
-    exists; QA-07 truthfulness). A completion failure after the primary
-    unlink leaves the retiring handle absent and its exact publication
-    pending; other non-``retired`` outcomes leave both handles loadable."""
+    was attempted); ``"cleanup_incomplete"`` (the primary commit did not
+    occur, so the retiring handle remains loadable). After the primary unlink,
+    the outcome is always ``"retired"``; ``info`` additively discloses durable
+    record cleanup state when publication completion needs recovery."""
     from ..storage.doc_store import RetirementConflict
     from ..storage.retirements import (
         begin_retirement,
@@ -222,6 +221,7 @@ def _execute_retirement(store, owner, repo_name, repo_id, target, family,
     )
     if not publication_id:
         return "record_unavailable", {}
+    delete_outcome = {}
     try:
         # jdoc#93 QA-23: this is the INTERNAL coordinated operation, already
         # mid-protocol with a published record on disk. A bounded wait for the
@@ -230,25 +230,38 @@ def _execute_retirement(store, owner, repo_name, repo_id, target, family,
         # public delete path is the one that must never silently wait.
         removed = store.delete_index(
             owner, repo_name, expected_fingerprints=fingerprints,
+            outcome=delete_outcome,
             lock_wait=True,
             retirement_publication=publication_id,
         )
     except RetirementConflict as conflict:
-        finish_retirement(
+        cleanup_finished = finish_retirement(
             store.base_path,
             owner,
             repo_name,
             publication_id=publication_id,
         )
-        return "conflict", {"changed_handles": conflict.changed}
+        info = {"changed_handles": conflict.changed}
+        if not cleanup_finished:
+            pending = pending_retirement(
+                store.base_path, owner, repo_name
+            )
+            if pending is not None:
+                info["retirement_cleanup_pending"] = True
+        return "conflict", info
     except Exception:
-        removed = False
+        removed = bool(delete_outcome.get("_primary_unlink_committed"))
+    cleanup_info = {
+        key: value
+        for key, value in delete_outcome.items()
+        if not key.startswith("_") and key != "reason_code"
+    }
     if not removed:
         info = {}
         if pending_retirement(store.base_path, owner, repo_name) is not None:
             info["pending_retirement"] = True
         return "cleanup_incomplete", info
-    return "retired", {}
+    return "retired", cleanup_info
 
 
 def _resolve_legacy_reconcile(
@@ -481,6 +494,7 @@ def _resolve_legacy_reconcile(
             "removed_handle": repo_id,
             "removed_file_count": len(s_docs),
             "certified_sha": s_sha,
+            **info,
             "detail": (
                 "The selected legacy index was proven an exact duplicate of "
                 "its modern peer (verified identity, same clean certified "
@@ -932,6 +946,7 @@ def _resolve_graduation(
                     "provisional_sha": p_sha,
                     "established_sha": e_sha,
                     "relationship": "provisional_is_strict_ancestor_of_established",
+                    **info,
                     "detail": (
                         "Git proved the provisional snapshot is a strict "
                         "ancestor of the established index's snapshot (same "
@@ -1086,6 +1101,7 @@ def _resolve_graduation(
                 "established_handle": target,
                 "removed_handle": f"{owner}/{repo_name}",
                 "removed_file_count": len(p_docs),
+                **info,
                 "detail": (
                     "Git lineage was verified; an established index for this "
                     "corpus already exists and every provisional file matches "

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -247,6 +247,133 @@ def test_publication_revalidates_fingerprints_after_lock_acquisition(
     ) is None
 
 
+@pytest.mark.parametrize("omitted", ["local/old", "local/modern"])
+def test_publication_requires_both_retirement_pair_fingerprints(
+    tmp_path, monkeypatch, omitted
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    fingerprints = _fingerprints(store)
+    fingerprints.pop(omitted)
+
+    publication = retirements.begin_retirement(
+        str(store_path),
+        "local",
+        "old",
+        retained="local/modern",
+        fingerprints=fingerprints,
+        family="qa19",
+    )
+
+    assert publication is None
+    assert retirements.retirement_record(
+        str(store_path), "local", "old"
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "retained", ["local/absent", "local/old", "../escape"]
+)
+def test_publication_requires_a_distinct_retained_handle_bound_to_the_proof(
+    tmp_path, monkeypatch, retained
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+
+    publication = retirements.begin_retirement(
+        str(store_path),
+        "local",
+        "old",
+        retained=retained,
+        fingerprints=_fingerprints(store),
+        family="qa19",
+    )
+
+    assert publication is None
+    assert retirements.retirement_record(
+        str(store_path), "local", "old"
+    ) is None
+
+
+def test_publication_rejects_fingerprints_outside_the_retirement_pair(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    other_path = store._index_path("local", "other")
+    other_path.write_bytes(store._index_path("local", "modern").read_bytes())
+    fingerprints = _fingerprints(store)
+    fingerprints["local/other"] = store.index_fingerprint("local", "other")
+    assert fingerprints["local/other"]
+
+    publication = retirements.begin_retirement(
+        str(store_path),
+        "local",
+        "old",
+        retained="local/modern",
+        fingerprints=fingerprints,
+        family="qa19",
+    )
+
+    assert publication is None
+    assert retirements.retirement_record(
+        str(store_path), "local", "old"
+    ) is None
+
+
+@pytest.mark.parametrize(
+    ("owner", "name", "escaped_record"),
+    [
+        ("../escape", "old", "outside-owner"),
+        ("local", "../escape", "outside-name"),
+    ],
+)
+def test_publication_rejects_an_unsafe_record_slot_before_path_creation(
+    tmp_path, monkeypatch, owner, name, escaped_record
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    if escaped_record == "outside-owner":
+        escaped_path = store_path.parent / "escape" / ".retirements" / "old.json"
+    else:
+        escaped_path = store_path / "local" / "escape.json"
+
+    publication = retirements.begin_retirement(
+        str(store_path),
+        owner,
+        name,
+        retained="local/modern",
+        fingerprints=_fingerprints(store),
+        family="qa19",
+    )
+
+    assert publication is None
+    assert escaped_path.exists() is False
+
+
+def test_final_gate_rejects_a_malformed_durable_retirement_pair(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    fingerprints = _fingerprints(store)
+    publication = _publish(store_path, store)
+    record_path = store_path / "local" / ".retirements" / "old.json"
+    real_commit = store._commit_guarded_retirement
+
+    def corrupt_pair_before_final_gate(*args, **kwargs):
+        record = json.loads(record_path.read_text(encoding="utf-8"))
+        record["retained"] = "local/absent"
+        record_path.write_text(
+            json.dumps(record, separators=(",", ":")), encoding="utf-8"
+        )
+        return real_commit(*args, **kwargs)
+
+    monkeypatch.setattr(
+        store, "_commit_guarded_retirement", corrupt_pair_before_final_gate
+    )
+
+    with pytest.raises(RetirementConflict):
+        _guarded_delete(store, fingerprints, publication)
+
+    assert store.load_index("local", "old") is not None
+
+
 def test_authoritative_record_lock_never_yields_without_a_lock(
     tmp_path, monkeypatch
 ):
@@ -341,16 +468,24 @@ def test_guarded_delete_cannot_adopt_a_replacement_publication(
 
 def test_guarded_delete_requires_a_current_publication(tmp_path, monkeypatch):
     store_path, store = _pair(tmp_path, monkeypatch)
+    fingerprints = _fingerprints(store)
+    publication = _publish(store_path, store)
+    record_path = store_path / "local" / ".retirements" / "old.json"
+    record_path.unlink()
+    outcome = {}
 
     with pytest.raises(RetirementConflict):
         store.delete_index(
             "local",
             "old",
-            expected_fingerprints=_fingerprints(store),
+            expected_fingerprints=fingerprints,
+            retirement_publication=publication,
+            outcome=outcome,
             lock_wait=True,
         )
 
     assert store.load_index("local", "old") is not None
+    assert outcome == {}
     assert retirements.retirement_record(
         str(store_path), "local", "old"
     ) is None
@@ -467,19 +602,24 @@ def test_guarded_delete_rejects_an_unreadable_publication(
     tmp_path, monkeypatch
 ):
     store_path, store = _pair(tmp_path, monkeypatch)
+    fingerprints = _fingerprints(store)
+    publication = _publish(store_path, store)
     record_path = store_path / "local" / ".retirements" / "old.json"
-    record_path.parent.mkdir(parents=True, exist_ok=True)
     record_path.write_text("{not-json", encoding="utf-8")
+    outcome = {}
 
     with pytest.raises(RetirementConflict):
         store.delete_index(
             "local",
             "old",
-            expected_fingerprints=_fingerprints(store),
+            expected_fingerprints=fingerprints,
+            retirement_publication=publication,
+            outcome=outcome,
             lock_wait=True,
         )
 
     assert store.load_index("local", "old") is not None
+    assert outcome == {}
     assert record_path.read_text(encoding="utf-8") == "{not-json"
 
 

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -1,0 +1,321 @@
+"""Issue #95 QA-19 lifecycle-authority regressions."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+from contextlib import contextmanager
+
+import pytest
+
+from jdocmunch_mcp.storage import retirements
+from jdocmunch_mcp.storage.doc_store import DocStore, RetirementConflict
+from tests import test_v1_110_0 as legacy
+
+
+def _pair(tmp_path, monkeypatch):
+    _, _, _, store_path = legacy._standard_pair(tmp_path, monkeypatch)
+    return store_path, DocStore(base_path=str(store_path))
+
+
+def _fingerprints(store):
+    values = {
+        "local/old": store.index_fingerprint("local", "old"),
+        "local/modern": store.index_fingerprint("local", "modern"),
+    }
+    assert all(values.values())
+    return values
+
+
+def _publish(store_path, store, retained="local/modern"):
+    return retirements.begin_retirement(
+        str(store_path),
+        "local",
+        "old",
+        retained=retained,
+        fingerprints=_fingerprints(store),
+        family="qa19",
+    )
+
+
+def _publication_worker(store_path, retained, ready, start, output):
+    store = DocStore(base_path=store_path)
+    ready.set()
+    if not start.wait(15):
+        raise TimeoutError("publisher start barrier was not released")
+    publication = retirements.begin_retirement(
+        store_path,
+        "local",
+        "old",
+        retained=retained,
+        fingerprints=_fingerprints(store),
+        family="qa19-process",
+    )
+    output.put(publication)
+
+
+def test_publication_receipt_is_unique_and_persisted(tmp_path, monkeypatch):
+    store_path, store = _pair(tmp_path, monkeypatch)
+
+    first = _publish(store_path, store)
+    second = _publish(store_path, store)
+    record = retirements.pending_retirement(str(store_path), "local", "old")
+
+    assert isinstance(first, str) and first
+    assert isinstance(second, str) and second
+    assert first != second
+    assert record["publication_id"] == second
+
+
+def test_older_completion_cannot_remove_newer_publication(tmp_path, monkeypatch):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    first = _publish(store_path, store)
+    second = _publish(store_path, store)
+
+    assert retirements.finish_retirement(
+        str(store_path), "local", "old", publication_id=first
+    ) is False
+    record = retirements.pending_retirement(str(store_path), "local", "old")
+    assert record["publication_id"] == second
+
+
+def test_publication_fails_closed_when_record_lock_is_unavailable(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    monkeypatch.setattr(retirements, "_acquire_fd", lambda *args, **kwargs: None)
+
+    assert _publish(store_path, store) is None
+    record_path = store_path / "local" / ".retirements" / "old.json"
+    assert record_path.exists() is False
+
+
+def test_publication_revalidates_fingerprints_after_lock_acquisition(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    fingerprints = _fingerprints(store)
+    retained_path = store._index_path("local", "modern")
+    real_acquire = retirements._acquire_fd
+    changed = False
+
+    def mutate_before_lock(lock_path, blocking):
+        nonlocal changed
+        if not changed:
+            changed = True
+            data = json.loads(retained_path.read_text(encoding="utf-8"))
+            data["source_dirty"] = not data.get("source_dirty", False)
+            retained_path.write_text(
+                json.dumps(data, separators=(",", ":")), encoding="utf-8"
+            )
+        return real_acquire(lock_path, blocking)
+
+    monkeypatch.setattr(retirements, "_acquire_fd", mutate_before_lock)
+    publication = retirements.begin_retirement(
+        str(store_path),
+        "local",
+        "old",
+        retained="local/modern",
+        fingerprints=fingerprints,
+        family="qa19",
+    )
+
+    assert changed is True
+    assert publication is None
+    assert retirements.retirement_record(
+        str(store_path), "local", "old"
+    ) is None
+
+
+def test_authoritative_record_lock_never_yields_without_a_lock(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(retirements, "_acquire_fd", lambda *args, **kwargs: None)
+
+    with pytest.raises(RuntimeError):
+        with retirements.hold_record_lock(str(tmp_path), "local", "old"):
+            pytest.fail("critical section entered without an authoritative lock")
+
+
+def test_completion_lock_failure_preserves_the_publication(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    publication = _publish(store_path, store)
+    monkeypatch.setattr(retirements, "_acquire_fd", lambda *args, **kwargs: None)
+
+    assert retirements.finish_retirement(
+        str(store_path), "local", "old", publication_id=publication
+    ) is False
+    current = retirements.retirement_record(str(store_path), "local", "old")
+    assert current["publication_id"] == publication
+
+
+def test_final_gate_lock_failure_keeps_the_retiring_monolith(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    publication = _publish(store_path, store)
+    monkeypatch.setattr(retirements, "_acquire_fd", lambda *args, **kwargs: None)
+
+    with pytest.raises(RetirementConflict):
+        store.delete_index(
+            "local",
+            "old",
+            expected_fingerprints=_fingerprints(store),
+            retirement_publication=publication,
+            lock_wait=True,
+        )
+
+    assert store.load_index("local", "old") is not None
+
+
+def test_final_gate_requires_the_exact_current_publication(tmp_path, monkeypatch):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    first = _publish(store_path, store)
+    second = _publish(store_path, store)
+
+    with pytest.raises(RetirementConflict):
+        store.delete_index(
+            "local",
+            "old",
+            expected_fingerprints=_fingerprints(store),
+            retirement_publication=first,
+            lock_wait=True,
+        )
+
+    assert store.load_index("local", "old") is not None
+    record = retirements.pending_retirement(str(store_path), "local", "old")
+    assert record["publication_id"] == second
+
+
+def test_fingerprints_are_reproved_after_the_retained_gate(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    publication = _publish(store_path, store)
+    fingerprints = _fingerprints(store)
+    retained_path = store._index_path("local", "modern")
+
+    @contextmanager
+    def mutate_after_gate(retained, owner, name):
+        data = json.loads(retained_path.read_text(encoding="utf-8"))
+        data["source_dirty"] = not data.get("source_dirty", False)
+        retained_path.write_text(
+            json.dumps(data, separators=(",", ":")), encoding="utf-8"
+        )
+        yield True
+
+    monkeypatch.setattr(store, "_gate_retained_handle", mutate_after_gate)
+
+    with pytest.raises(RetirementConflict):
+        store.delete_index(
+            "local",
+            "old",
+            expected_fingerprints=fingerprints,
+            retirement_publication=publication,
+            lock_wait=True,
+        )
+
+    assert store.load_index("local", "old") is not None
+
+
+def test_reverse_scan_revalidates_candidate_under_its_lock(tmp_path, monkeypatch):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    first = _publish(store_path, store)
+    record_path = store_path / "local" / ".retirements" / "old.json"
+    replacement = json.loads(record_path.read_text(encoding="utf-8"))
+    replacement["publication_id"] = f"{first}-replacement"
+    replacement["retained"] = "local/other"
+    real_acquire = retirements._acquire_fd
+    replaced = False
+
+    def replace_before_lock(lock_path, blocking):
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            record_path.write_text(
+                json.dumps(replacement, separators=(",", ":")),
+                encoding="utf-8",
+            )
+        return real_acquire(lock_path, blocking)
+
+    monkeypatch.setattr(retirements, "_acquire_fd", replace_before_lock)
+    retirements.void_retirements_referencing(
+        str(store_path), "local/modern"
+    )
+
+    assert replaced is True
+    current = json.loads(record_path.read_text(encoding="utf-8"))
+    assert current["publication_id"] == replacement["publication_id"]
+
+
+def test_stale_self_healing_revalidates_missing_index_under_lock(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    first = _publish(store_path, store)
+    record_path = store_path / "local" / ".retirements" / "old.json"
+    retiring_path = store._index_path("local", "old")
+    retiring_bytes = retiring_path.read_bytes()
+    retiring_path.unlink()
+    replacement = json.loads(record_path.read_text(encoding="utf-8"))
+    replacement["publication_id"] = f"{first}-replacement"
+    real_acquire = retirements._acquire_fd
+    replaced = False
+
+    def recreate_before_lock(lock_path, blocking):
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            retiring_path.write_bytes(retiring_bytes)
+            record_path.write_text(
+                json.dumps(replacement, separators=(",", ":")),
+                encoding="utf-8",
+            )
+        return real_acquire(lock_path, blocking)
+
+    monkeypatch.setattr(retirements, "_acquire_fd", recreate_before_lock)
+    current = retirements.pending_retirement(str(store_path), "local", "old")
+
+    assert replaced is True
+    assert current["publication_id"] == replacement["publication_id"]
+    assert record_path.exists()
+
+
+def test_cross_process_older_cleanup_cannot_remove_winning_publication(
+    tmp_path, monkeypatch
+):
+    store_path, _ = _pair(tmp_path, monkeypatch)
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    ready = [context.Event(), context.Event()]
+    output = context.Queue()
+    publishers = [
+        context.Process(
+            target=_publication_worker,
+            args=(str(store_path), retained, signal, start, output),
+        )
+        for retained, signal in zip(
+            ("local/modern", "local/modern"), ready, strict=True
+        )
+    ]
+
+    for process in publishers:
+        process.start()
+    assert all(signal.wait(15) for signal in ready)
+    start.set()
+    publications = [output.get(timeout=15), output.get(timeout=15)]
+    for process in publishers:
+        process.join(15)
+        assert process.exitcode == 0
+
+    record = retirements.pending_retirement(str(store_path), "local", "old")
+    winner = record["publication_id"]
+    loser = next(publication for publication in publications if publication != winner)
+    assert retirements.finish_retirement(
+        str(store_path), "local", "old", publication_id=loser
+    ) is False
+    assert retirements.pending_retirement(
+        str(store_path), "local", "old"
+    )["publication_id"] == winner

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import multiprocessing
 from contextlib import contextmanager
@@ -39,6 +40,34 @@ def _publish(store_path, store, retained="local/modern"):
     )
 
 
+def _supports_publication_receipts() -> bool:
+    return (
+        "retirement_publication"
+        in inspect.signature(DocStore.delete_index).parameters
+    )
+
+
+def _finish_retirement(store_path, publication):
+    kwargs = {}
+    if "publication_id" in inspect.signature(
+        retirements.finish_retirement
+    ).parameters:
+        kwargs["publication_id"] = publication
+    return retirements.finish_retirement(
+        str(store_path), "local", "old", **kwargs
+    )
+
+
+def _guarded_delete(store, fingerprints, publication, *, lock_wait=True):
+    kwargs = {
+        "expected_fingerprints": fingerprints,
+        "lock_wait": lock_wait,
+    }
+    if _supports_publication_receipts():
+        kwargs["retirement_publication"] = publication
+    return store.delete_index("local", "old", **kwargs)
+
+
 def _publication_worker(store_path, retained, ready, start, output):
     store = DocStore(base_path=store_path)
     ready.set()
@@ -73,9 +102,7 @@ def test_older_completion_cannot_remove_newer_publication(tmp_path, monkeypatch)
     first = _publish(store_path, store)
     second = _publish(store_path, store)
 
-    assert retirements.finish_retirement(
-        str(store_path), "local", "old", publication_id=first
-    ) is False
+    assert _finish_retirement(store_path, first) is False
     record = retirements.pending_retirement(str(store_path), "local", "old")
     assert record["publication_id"] == second
 
@@ -145,9 +172,7 @@ def test_completion_lock_failure_preserves_the_publication(
     publication = _publish(store_path, store)
     monkeypatch.setattr(retirements, "_acquire_fd", lambda *args, **kwargs: None)
 
-    assert retirements.finish_retirement(
-        str(store_path), "local", "old", publication_id=publication
-    ) is False
+    assert _finish_retirement(store_path, publication) is False
     current = retirements.retirement_record(str(store_path), "local", "old")
     assert current["publication_id"] == publication
 
@@ -160,12 +185,10 @@ def test_final_gate_lock_failure_keeps_the_retiring_monolith(
     monkeypatch.setattr(retirements, "_acquire_fd", lambda *args, **kwargs: None)
 
     with pytest.raises(RetirementConflict):
-        store.delete_index(
-            "local",
-            "old",
-            expected_fingerprints=_fingerprints(store),
-            retirement_publication=publication,
-            lock_wait=True,
+        _guarded_delete(
+            store,
+            _fingerprints(store),
+            publication,
         )
 
     assert store.load_index("local", "old") is not None
@@ -177,12 +200,10 @@ def test_final_gate_requires_the_exact_current_publication(tmp_path, monkeypatch
     second = _publish(store_path, store)
 
     with pytest.raises(RetirementConflict):
-        store.delete_index(
-            "local",
-            "old",
-            expected_fingerprints=_fingerprints(store),
-            retirement_publication=first,
-            lock_wait=True,
+        _guarded_delete(
+            store,
+            _fingerprints(store),
+            first,
         )
 
     assert store.load_index("local", "old") is not None
@@ -194,23 +215,30 @@ def test_guarded_delete_cannot_adopt_a_replacement_publication(
     tmp_path, monkeypatch
 ):
     store_path, store = _pair(tmp_path, monkeypatch)
-    first = _publish(store_path, store)
-    second = _publish(store_path, store)
-    assert first != second
+    _publish(store_path, store)
+    current_publication = _publish(store_path, store)
 
-    with pytest.raises(RetirementConflict):
+    try:
         store.delete_index(
             "local",
             "old",
             expected_fingerprints=_fingerprints(store),
             lock_wait=True,
         )
+    except RetirementConflict:
+        assert _supports_publication_receipts()
+    else:
+        assert not _supports_publication_receipts()
+        assert store.load_index("local", "old") is None
+        pytest.fail(
+            "receiptless guarded deletion adopted the replacement publication"
+        )
 
     assert store.load_index("local", "old") is not None
     record = retirements.retirement_record(
         str(store_path), "local", "old"
     )
-    assert record["publication_id"] == second
+    assert record["publication_id"] == current_publication
 
 
 def test_guarded_delete_requires_a_current_publication(tmp_path, monkeypatch):
@@ -378,12 +406,10 @@ def test_fingerprints_are_reproved_after_the_retained_gate(
     monkeypatch.setattr(store, "_gate_retained_handle", mutate_after_gate)
 
     with pytest.raises(RetirementConflict):
-        store.delete_index(
-            "local",
-            "old",
-            expected_fingerprints=fingerprints,
-            retirement_publication=publication,
-            lock_wait=True,
+        _guarded_delete(
+            store,
+            fingerprints,
+            publication,
         )
 
     assert store.load_index("local", "old") is not None
@@ -480,11 +506,14 @@ def test_cross_process_older_cleanup_cannot_remove_winning_publication(
         assert process.exitcode == 0
 
     record = retirements.pending_retirement(str(store_path), "local", "old")
-    winner = record["publication_id"]
+    winner = record.get("publication_id")
+    if not isinstance(winner, str):
+        assert _finish_retirement(store_path, publications[0]) is False
+        pytest.fail(
+            "retirement completion lacked exact publication ownership"
+        )
     loser = next(publication for publication in publications if publication != winner)
-    assert retirements.finish_retirement(
-        str(store_path), "local", "old", publication_id=loser
-    ) is False
+    assert _finish_retirement(store_path, loser) is False
     assert retirements.pending_retirement(
         str(store_path), "local", "old"
     )["publication_id"] == winner

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -322,23 +322,108 @@ def test_guarded_delete_requires_a_current_publication(tmp_path, monkeypatch):
 def test_empty_expected_fingerprints_never_authorize_a_delete(
     tmp_path, monkeypatch
 ):
-    """An empty proof asserts nothing and must not degrade to unguarded.
+    """An empty proof asserts nothing, receipt or no receipt.
 
-    ``expected_fingerprints={}`` selects the guarded path (any dict does), so
-    it needs a publication receipt like every other guarded delete and fails
-    closed without one. Before Issue #95 the emptiness itself was read as
-    "unguarded" and the index was removed with no proof at all.
+    Two distinct refusals, and the second is the one that matters. Without a
+    receipt the call is rejected for the missing receipt. WITH a valid
+    receipt, an empty map must still be refused — otherwise the receipt is a
+    password rather than a proof, and its holder can authorize a commit while
+    asserting nothing about either participant.
     """
     store_path, store = _pair(tmp_path, monkeypatch)
 
+    # No receipt.
     with pytest.raises(RetirementConflict):
         store.delete_index(
             "local", "old", expected_fingerprints={}, lock_wait=False
         )
-
     assert store.load_index("local", "old") is not None
+
+    # Valid receipt, empty proof. Red against 914a285, which returned True
+    # and removed the retiring index.
+    publication = _publish(store_path, store)
+    assert publication
+    with pytest.raises(RetirementConflict):
+        store.delete_index(
+            "local", "old",
+            expected_fingerprints={},
+            retirement_publication=publication,
+            lock_wait=True,
+        )
+    assert store.load_index("local", "old") is not None
+    assert store.load_index("local", "modern") is not None
+
     # Omitting the argument entirely still selects the unguarded path.
     assert store.delete_index("local", "old", lock_wait=False) is True
+
+
+def test_partial_proof_cannot_hide_a_changed_retained_peer(
+    tmp_path, monkeypatch
+):
+    """The gate verifies the DURABLE proof, not the caller's copy of it.
+
+    The publication records fingerprints for both participants. A caller that
+    supplies only the retiring handle's fingerprint would, if the gate trusted
+    the argument, commit without ever looking at the retained peer — so a peer
+    that changed after publication goes unnoticed and AC-02 is violated.
+
+    The peer is mutated on disk rather than through ``save_index`` so no
+    record-voiding path runs: the publication stays current and the ONLY thing
+    standing between the caller and an unauthorized commit is proof binding.
+    Red against 914a285, which returned True.
+    """
+    store_path, store = _pair(tmp_path, monkeypatch)
+    fingerprints = _fingerprints(store)
+    publication = retirements.begin_retirement(
+        str(store_path), "local", "old",
+        retained="local/modern", fingerprints=fingerprints, family="qa19",
+    )
+    assert publication
+
+    retained_path = store._index_path("local", "modern")
+    data = json.loads(retained_path.read_text(encoding="utf-8"))
+    data["source_dirty"] = not data.get("source_dirty", False)
+    retained_path.write_text(
+        json.dumps(data, separators=(",", ":")), encoding="utf-8"
+    )
+    assert store.index_fingerprint("local", "modern") != (
+        fingerprints["local/modern"]
+    )
+    assert retirements.retirement_record(
+        str(store_path), "local", "old"
+    )["publication_id"] == publication
+
+    with pytest.raises(RetirementConflict):
+        store.delete_index(
+            "local", "old",
+            expected_fingerprints={"local/old": fingerprints["local/old"]},
+            retirement_publication=publication,
+            lock_wait=True,
+        )
+
+    assert store.load_index("local", "old") is not None
+
+
+def test_altered_proof_values_are_refused(tmp_path, monkeypatch):
+    """A map with the right keys but a wrong value is not the published one."""
+    store_path, store = _pair(tmp_path, monkeypatch)
+    fingerprints = _fingerprints(store)
+    publication = _publish(store_path, store)
+    assert publication
+
+    altered = dict(fingerprints)
+    altered["local/modern"] = "0" * 64
+
+    with pytest.raises(RetirementConflict):
+        store.delete_index(
+            "local", "old",
+            expected_fingerprints=altered,
+            retirement_publication=publication,
+            lock_wait=True,
+        )
+
+    assert store.load_index("local", "old") is not None
+    assert store.load_index("local", "modern") is not None
 
 
 def test_guarded_delete_rejects_an_unreadable_publication(

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -104,6 +104,42 @@ def _publication_worker(store_path, retained, ready, start, output):
     output.put(publication)
 
 
+def test_proof_and_record_side_fingerprints_are_one_implementation(
+    tmp_path, monkeypatch
+):
+    """Both sides of the proof must compute the identical token.
+
+    ``DocStore.index_fingerprint`` captures the token and
+    ``begin_retirement`` re-proves it under the record lock. If those ever
+    disagreed by a byte, publication would refuse itself and every retirement
+    would silently become ``record_unavailable`` — a failure that no
+    behavioural test reads as a fingerprint bug.
+    """
+    store_path, store = _pair(tmp_path, monkeypatch)
+
+    for owner, name in (("local", "old"), ("local", "modern")):
+        assert retirements._fingerprint_handle(
+            str(store_path), f"{owner}/{name}"
+        ) == store.index_fingerprint(owner, name)
+
+    # Both report None for a handle with no stored monolith, rather than one
+    # raising and the other returning a hash of something else.
+    assert retirements._fingerprint_handle(
+        str(store_path), "local/absent"
+    ) is None
+    assert store.index_fingerprint("local", "absent") is None
+
+
+@pytest.mark.parametrize(
+    "handle",
+    ["../escape", "local/../../escape", "./local", "local/.", "noslash", ""],
+)
+def test_unsafe_handles_never_reach_the_filesystem(tmp_path, monkeypatch, handle):
+    """A handle that could traverse out of the store fails closed."""
+    store_path, _ = _pair(tmp_path, monkeypatch)
+    assert retirements._fingerprint_handle(str(store_path), handle) is None
+
+
 def test_publication_receipt_is_unique_and_persisted(tmp_path, monkeypatch):
     store_path, store = _pair(tmp_path, monkeypatch)
 

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -190,6 +190,29 @@ def test_final_gate_requires_the_exact_current_publication(tmp_path, monkeypatch
     assert record["publication_id"] == second
 
 
+def test_guarded_delete_cannot_adopt_a_replacement_publication(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    first = _publish(store_path, store)
+    second = _publish(store_path, store)
+    assert first != second
+
+    with pytest.raises(RetirementConflict):
+        store.delete_index(
+            "local",
+            "old",
+            expected_fingerprints=_fingerprints(store),
+            lock_wait=True,
+        )
+
+    assert store.load_index("local", "old") is not None
+    record = retirements.retirement_record(
+        str(store_path), "local", "old"
+    )
+    assert record["publication_id"] == second
+
+
 def test_guarded_delete_requires_a_current_publication(tmp_path, monkeypatch):
     store_path, store = _pair(tmp_path, monkeypatch)
 
@@ -227,7 +250,7 @@ def test_guarded_delete_rejects_an_unreadable_publication(
     assert record_path.read_text(encoding="utf-8") == "{not-json"
 
 
-def test_completion_unlink_failure_reports_pending_cleanup(
+def test_completion_unlink_failure_reports_retired_with_pending_cleanup(
     tmp_path, monkeypatch
 ):
     _, worktree, _, store_path = legacy._standard_pair(
@@ -250,8 +273,9 @@ def test_completion_unlink_failure_reports_pending_cleanup(
     )
 
     block = result["legacy_reconciliation"]
-    assert block["reason_code"] == wc.REASON_LEGACY_CLEANUP_INCOMPLETE
-    assert block["pending_retirement"] is True
+    assert block["reason_code"] == wc.REASON_LEGACY_RECONCILED
+    assert block["retirement_cleanup_pending"] is True
+    assert block["retirement_completion_marker_persisted"] is True
     record = retirements.pending_retirement(
         str(store_path), "local", "old"
     )
@@ -260,6 +284,78 @@ def test_completion_unlink_failure_reports_pending_cleanup(
     store = DocStore(base_path=str(store_path))
     assert store.load_index("local", "old") is None
     assert store.load_index("local", "modern") is not None
+
+
+def test_marker_persistence_failure_is_disclosed_from_durable_state(
+    tmp_path, monkeypatch
+):
+    _, worktree, _, store_path = legacy._standard_pair(
+        tmp_path, monkeypatch
+    )
+    record_path = store_path / "local" / ".retirements" / "old.json"
+    real_unlink = type(record_path).unlink
+    real_replace = retirements.os.replace
+    record_replacements = 0
+
+    def fail_record_unlink(path, *args, **kwargs):
+        if path == record_path:
+            raise OSError("injected publication completion failure")
+        return real_unlink(path, *args, **kwargs)
+
+    def fail_marker_replace(source, destination, *args, **kwargs):
+        nonlocal record_replacements
+        if destination == record_path:
+            record_replacements += 1
+            if record_replacements > 1:
+                raise OSError("injected completion marker failure")
+        return real_replace(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(type(record_path), "unlink", fail_record_unlink)
+    monkeypatch.setattr(retirements.os, "replace", fail_marker_replace)
+
+    result = legacy._index(
+        worktree / "docs",
+        "old",
+        store_path,
+        legacy_reconcile="apply",
+    )
+
+    block = result["legacy_reconciliation"]
+    assert block["reason_code"] == wc.REASON_LEGACY_RECONCILED
+    assert block["retirement_cleanup_pending"] is True
+    assert block["retirement_completion_marker_persisted"] is False
+    record = retirements.pending_retirement(
+        str(store_path), "local", "old"
+    )
+    assert record is not None
+    assert record.get("completion_pending") is not True
+    store = DocStore(base_path=str(store_path))
+    assert store.load_index("local", "old") is None
+    assert store.load_index("local", "modern") is not None
+
+
+def test_pending_read_reports_record_when_stale_cleanup_unlink_fails(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    publication = _publish(store_path, store)
+    record_path = store_path / "local" / ".retirements" / "old.json"
+    store._index_path("local", "old").unlink()
+    real_unlink = type(record_path).unlink
+
+    def fail_record_unlink(path, *args, **kwargs):
+        if path == record_path:
+            raise OSError("injected stale-record cleanup failure")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(type(record_path), "unlink", fail_record_unlink)
+
+    record = retirements.pending_retirement(
+        str(store_path), "local", "old"
+    )
+    assert record is not None
+    assert record["publication_id"] == publication
+    assert record_path.exists()
 
 
 def test_fingerprints_are_reproved_after_the_retained_gate(

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -50,13 +50,32 @@ def _supports_publication_receipts() -> bool:
 
 def _finish_retirement(store_path, publication):
     kwargs = {}
-    if "publication_id" in inspect.signature(
-        retirements.finish_retirement
-    ).parameters:
+    if _finish_supports_publication_id():
         kwargs["publication_id"] = publication
     return retirements.finish_retirement(
         str(store_path), "local", "old", **kwargs
     )
+
+
+def _finish_supports_publication_id() -> bool:
+    return (
+        "publication_id"
+        in inspect.signature(retirements.finish_retirement).parameters
+    )
+
+
+def _assert_conditional_finish_refusal(result) -> None:
+    if _finish_supports_publication_id():
+        assert result is False
+
+
+def _current_retirement_record(store_path):
+    reader = getattr(
+        retirements,
+        "retirement_record",
+        retirements.pending_retirement,
+    )
+    return reader(str(store_path), "local", "old")
 
 
 def _guarded_delete(store, fingerprints, publication, *, lock_wait=True):
@@ -103,9 +122,16 @@ def test_older_completion_cannot_remove_newer_publication(tmp_path, monkeypatch)
     first = _publish(store_path, store)
     second = _publish(store_path, store)
 
-    assert _finish_retirement(store_path, first) is False
+    _assert_conditional_finish_refusal(
+        _finish_retirement(store_path, first)
+    )
     record = retirements.pending_retirement(str(store_path), "local", "old")
-    assert record["publication_id"] == second
+    assert record is not None
+    publication_id = record.get("publication_id")
+    assert isinstance(publication_id, str), (
+        "retirement record lacks stable publication identity"
+    )
+    assert publication_id == second
 
 
 def test_publication_fails_closed_when_record_lock_is_unavailable(
@@ -173,9 +199,16 @@ def test_completion_lock_failure_preserves_the_publication(
     publication = _publish(store_path, store)
     monkeypatch.setattr(retirements, "_acquire_fd", lambda *args, **kwargs: None)
 
-    assert _finish_retirement(store_path, publication) is False
-    current = retirements.retirement_record(str(store_path), "local", "old")
-    assert current["publication_id"] == publication
+    _assert_conditional_finish_refusal(
+        _finish_retirement(store_path, publication)
+    )
+    current = _current_retirement_record(store_path)
+    assert current is not None
+    publication_id = current.get("publication_id")
+    assert isinstance(publication_id, str), (
+        "retirement record lacks stable publication identity"
+    )
+    assert publication_id == publication
 
 
 def test_final_gate_lock_failure_keeps_the_retiring_monolith(
@@ -523,14 +556,25 @@ def test_cross_process_older_cleanup_cannot_remove_winning_publication(
         assert process.exitcode == 0
 
     record = retirements.pending_retirement(str(store_path), "local", "old")
+    assert record is not None
     winner = record.get("publication_id")
     if not isinstance(winner, str):
-        assert _finish_retirement(store_path, publications[0]) is False
+        _assert_conditional_finish_refusal(
+            _finish_retirement(store_path, publications[0])
+        )
         pytest.fail(
             "retirement completion lacked exact publication ownership"
         )
     loser = next(publication for publication in publications if publication != winner)
-    assert _finish_retirement(store_path, loser) is False
-    assert retirements.pending_retirement(
+    _assert_conditional_finish_refusal(
+        _finish_retirement(store_path, loser)
+    )
+    current = retirements.pending_retirement(
         str(store_path), "local", "old"
-    )["publication_id"] == winner
+    )
+    assert current is not None
+    publication_id = current.get("publication_id")
+    assert isinstance(publication_id, str), (
+        "retirement record lacks stable publication identity"
+    )
+    assert publication_id == winner

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -623,6 +623,19 @@ def test_guarded_delete_rejects_an_unreadable_publication(
     assert record_path.read_text(encoding="utf-8") == "{not-json"
 
 
+def test_publication_fails_closed_without_a_supported_lock_primitive(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    monkeypatch.setattr(retirements, "fcntl", None)
+    monkeypatch.setattr(retirements, "msvcrt", None)
+
+    assert _publish(store_path, store) is None
+    assert retirements.retirement_record(
+        str(store_path), "local", "old"
+    ) is None
+
+
 def test_completion_unlink_failure_reports_retired_with_pending_cleanup(
     tmp_path, monkeypatch
 ):

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -41,7 +41,7 @@ def _publish(store_path, store, retained="local/modern"):
 
 
 def _finish_retirement(store_path, publication):
-    """Complete exactly ``publication`` — refused unless it is still current."""
+    """Complete exactly ``publication``, refused unless it is still current."""
     return retirements.finish_retirement(
         str(store_path), "local", "old", publication_id=publication
     )
@@ -85,7 +85,7 @@ def test_proof_and_record_side_fingerprints_are_one_implementation(
     ``DocStore.index_fingerprint`` captures the token and
     ``begin_retirement`` re-proves it under the record lock. If those ever
     disagreed by a byte, publication would refuse itself and every retirement
-    would silently become ``record_unavailable`` — a failure that no
+    would silently become ``record_unavailable``, a failure that no
     behavioural test reads as a fingerprint bug.
     """
     store_path, store = _pair(tmp_path, monkeypatch)
@@ -109,8 +109,8 @@ def test_traversing_handle_never_hashes_a_file_outside_the_store(
     """An escaping handle must not be hashed from wherever it points.
 
     Without component validation, ``../escape`` joins to a path OUTSIDE the
-    store and the fingerprint is computed from that file — a retirement proof
-    token derived from something the store does not own. The planted file and
+    store and the fingerprint is computed from that file, yielding a retirement
+    proof token derived from something the store does not own. The planted file and
     the path assertion below keep this from passing vacuously: the naive join
     really does reach it.
     """
@@ -138,7 +138,7 @@ def test_drive_relative_handle_never_escapes_the_store(tmp_path, monkeypatch):
     """Windows drive-relative syntax is traversal without a separator.
 
     ``C:..`` contains no separator and is neither ``.`` nor ``..``, so a
-    hand-rolled "no separators, no dots" rule admits it — but Windows resolves
+    hand-rolled "no separators, no dots" rule admits it, but Windows resolves
     it drive-relative, so the join walks out of the store and hashes whatever
     it lands on. Only the canonical component policy rejects it.
     """
@@ -363,7 +363,7 @@ def test_empty_expected_fingerprints_never_authorize_a_delete(
 
     Two distinct refusals, and the second is the one that matters. Without a
     receipt the call is rejected for the missing receipt. WITH a valid
-    receipt, an empty map must still be refused — otherwise the receipt is a
+    receipt, an empty map must still be refused; otherwise the receipt is a
     password rather than a proof, and its holder can authorize a commit while
     asserting nothing about either participant.
     """
@@ -401,7 +401,7 @@ def test_partial_proof_cannot_hide_a_changed_retained_peer(
 
     The publication records fingerprints for both participants. A caller that
     supplies only the retiring handle's fingerprint would, if the gate trusted
-    the argument, commit without ever looking at the retained peer — so a peer
+    the argument, commit without ever looking at the retained peer, so a peer
     that changed after publication goes unnoticed and AC-02 is violated.
 
     The peer is mutated on disk rather than through ``save_index`` so no
@@ -588,7 +588,7 @@ def test_unreadable_record_after_commit_is_disclosed_as_unowned(
 
     The completion unlink fails and the record becomes unparseable in the same
     step, so the emitter cannot confirm the publication it just completed. It
-    must say so — ``unreadable`` and not owned — rather than reporting the
+    must say so, reporting ``unreadable`` and not owned, rather than the
     publication identity it was holding in memory.
     """
     _, worktree, _, store_path = legacy._standard_pair(

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -10,6 +10,7 @@ import pytest
 
 from jdocmunch_mcp.storage import retirements
 from jdocmunch_mcp.storage.doc_store import DocStore, RetirementConflict
+from jdocmunch_mcp.tools import _worktree_corpus as wc
 from tests import test_v1_110_0 as legacy
 
 
@@ -187,6 +188,78 @@ def test_final_gate_requires_the_exact_current_publication(tmp_path, monkeypatch
     assert store.load_index("local", "old") is not None
     record = retirements.pending_retirement(str(store_path), "local", "old")
     assert record["publication_id"] == second
+
+
+def test_guarded_delete_requires_a_current_publication(tmp_path, monkeypatch):
+    store_path, store = _pair(tmp_path, monkeypatch)
+
+    with pytest.raises(RetirementConflict):
+        store.delete_index(
+            "local",
+            "old",
+            expected_fingerprints=_fingerprints(store),
+            lock_wait=True,
+        )
+
+    assert store.load_index("local", "old") is not None
+    assert retirements.retirement_record(
+        str(store_path), "local", "old"
+    ) is None
+
+
+def test_guarded_delete_rejects_an_unreadable_publication(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    record_path = store_path / "local" / ".retirements" / "old.json"
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    record_path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(RetirementConflict):
+        store.delete_index(
+            "local",
+            "old",
+            expected_fingerprints=_fingerprints(store),
+            lock_wait=True,
+        )
+
+    assert store.load_index("local", "old") is not None
+    assert record_path.read_text(encoding="utf-8") == "{not-json"
+
+
+def test_completion_unlink_failure_reports_pending_cleanup(
+    tmp_path, monkeypatch
+):
+    _, worktree, _, store_path = legacy._standard_pair(
+        tmp_path, monkeypatch
+    )
+    record_path = store_path / "local" / ".retirements" / "old.json"
+    real_unlink = type(record_path).unlink
+
+    def fail_record_unlink(path, *args, **kwargs):
+        if path == record_path:
+            raise OSError("injected publication completion failure")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(type(record_path), "unlink", fail_record_unlink)
+    result = legacy._index(
+        worktree / "docs",
+        "old",
+        store_path,
+        legacy_reconcile="apply",
+    )
+
+    block = result["legacy_reconciliation"]
+    assert block["reason_code"] == wc.REASON_LEGACY_CLEANUP_INCOMPLETE
+    assert block["pending_retirement"] is True
+    record = retirements.pending_retirement(
+        str(store_path), "local", "old"
+    )
+    assert isinstance(record["publication_id"], str)
+    assert record["publication_id"]
+    store = DocStore(base_path=str(store_path))
+    assert store.load_index("local", "old") is None
+    assert store.load_index("local", "modern") is not None
 
 
 def test_fingerprints_are_reproved_after_the_retained_gate(

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -328,6 +328,28 @@ def test_guarded_delete_requires_a_current_publication(tmp_path, monkeypatch):
     ) is None
 
 
+def test_empty_expected_fingerprints_never_authorize_a_delete(
+    tmp_path, monkeypatch
+):
+    """An empty proof asserts nothing and must not degrade to unguarded.
+
+    ``expected_fingerprints={}`` selects the guarded path (any dict does), so
+    it needs a publication receipt like every other guarded delete and fails
+    closed without one. Before Issue #95 the emptiness itself was read as
+    "unguarded" and the index was removed with no proof at all.
+    """
+    store_path, store = _pair(tmp_path, monkeypatch)
+
+    with pytest.raises(RetirementConflict):
+        store.delete_index(
+            "local", "old", expected_fingerprints={}, lock_wait=False
+        )
+
+    assert store.load_index("local", "old") is not None
+    # Omitting the argument entirely still selects the unguarded path.
+    assert store.delete_index("local", "old", lock_wait=False) is True
+
+
 def test_guarded_delete_rejects_an_unreadable_publication(
     tmp_path, monkeypatch
 ):

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -361,6 +361,61 @@ def test_completion_unlink_failure_reports_retired_with_pending_cleanup(
     assert store.load_index("local", "modern") is not None
 
 
+def test_conflict_cleanup_failure_uses_precommit_pending_signal(
+    tmp_path, monkeypatch
+):
+    _, worktree, _, store_path = legacy._standard_pair(
+        tmp_path, monkeypatch
+    )
+    record_path = (
+        store_path / "local" / ".retirements" / "old.json"
+    )
+    real_unlink = type(record_path).unlink
+
+    def refuse_guarded_delete(self, *args, **kwargs):
+        raise RetirementConflict(["local/modern"])
+
+    def fail_record_unlink(path, *args, **kwargs):
+        if path == record_path:
+            raise OSError("injected pre-commit record cleanup failure")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(DocStore, "delete_index", refuse_guarded_delete)
+    monkeypatch.setattr(type(record_path), "unlink", fail_record_unlink)
+
+    result = legacy._index(
+        worktree / "docs",
+        "old",
+        store_path,
+        legacy_reconcile="apply",
+    )
+
+    block = result["legacy_reconciliation"]
+    assert set(block) == {
+        "state",
+        "reason_code",
+        "detail",
+        "established_handle",
+        "changed_handles",
+        "pending_retirement",
+    }
+    assert block["reason_code"] == wc.REASON_LEGACY_CONFLICT
+    assert block["pending_retirement"] is True
+    cleanup_schema = getattr(
+        storage_module, "RETIREMENT_CLEANUP_OUTCOME_SCHEMA", {}
+    )
+    assert set(block).isdisjoint(cleanup_schema)
+    record = retirements.pending_retirement(
+        str(store_path), "local", "old"
+    )
+    assert record is not None
+    assert isinstance(record.get("publication_id"), str)
+    assert record_path.exists()
+    store = DocStore(base_path=str(store_path))
+    assert store.load_index("local", "old") is not None
+    assert store.load_index("local", "modern") is not None
+
+
 def test_marker_persistence_failure_is_disclosed_from_durable_state(
     tmp_path, monkeypatch
 ):

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -103,12 +103,33 @@ def test_proof_and_record_side_fingerprints_are_one_implementation(
     assert store.index_fingerprint("local", "absent") is None
 
 
+def test_traversing_handle_never_hashes_a_file_outside_the_store(
+    tmp_path, monkeypatch
+):
+    """An escaping handle must not be hashed from wherever it points.
+
+    Without component validation, ``../escape`` joins to a path OUTSIDE the
+    store and the fingerprint is computed from that file — a retirement proof
+    token derived from something the store does not own. The planted file and
+    the path assertion below keep this from passing vacuously: the naive join
+    really does reach it.
+    """
+    store_path, _ = _pair(tmp_path, monkeypatch)
+    outside = store_path.parent / "escape.json"
+    outside.write_text("not part of this store", encoding="utf-8")
+    assert (store_path / ".." / "escape.json").resolve() == outside.resolve()
+
+    assert retirements._fingerprint_handle(
+        str(store_path), "../escape"
+    ) is None
+
+
 @pytest.mark.parametrize(
     "handle",
-    ["../escape", "local/../../escape", "./local", "local/.", "noslash", ""],
+    ["local/../../escape", "./local", "local/.", "noslash", ""],
 )
-def test_unsafe_handles_never_reach_the_filesystem(tmp_path, monkeypatch, handle):
-    """A handle that could traverse out of the store fails closed."""
+def test_unsafe_handles_fail_closed(tmp_path, monkeypatch, handle):
+    """The remaining malformed shapes never produce a proof token."""
     store_path, _ = _pair(tmp_path, monkeypatch)
     assert retirements._fingerprint_handle(str(store_path), handle) is None
 

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 import json
 import multiprocessing
 from contextlib import contextmanager
@@ -41,51 +40,25 @@ def _publish(store_path, store, retained="local/modern"):
     )
 
 
-def _supports_publication_receipts() -> bool:
-    return (
-        "retirement_publication"
-        in inspect.signature(DocStore.delete_index).parameters
-    )
-
-
 def _finish_retirement(store_path, publication):
-    kwargs = {}
-    if _finish_supports_publication_id():
-        kwargs["publication_id"] = publication
+    """Complete exactly ``publication`` — refused unless it is still current."""
     return retirements.finish_retirement(
-        str(store_path), "local", "old", **kwargs
+        str(store_path), "local", "old", publication_id=publication
     )
-
-
-def _finish_supports_publication_id() -> bool:
-    return (
-        "publication_id"
-        in inspect.signature(retirements.finish_retirement).parameters
-    )
-
-
-def _assert_conditional_finish_refusal(result) -> None:
-    if _finish_supports_publication_id():
-        assert result is False
 
 
 def _current_retirement_record(store_path):
-    reader = getattr(
-        retirements,
-        "retirement_record",
-        retirements.pending_retirement,
-    )
-    return reader(str(store_path), "local", "old")
+    return retirements.retirement_record(str(store_path), "local", "old")
 
 
 def _guarded_delete(store, fingerprints, publication, *, lock_wait=True):
-    kwargs = {
-        "expected_fingerprints": fingerprints,
-        "lock_wait": lock_wait,
-    }
-    if _supports_publication_receipts():
-        kwargs["retirement_publication"] = publication
-    return store.delete_index("local", "old", **kwargs)
+    return store.delete_index(
+        "local",
+        "old",
+        expected_fingerprints=fingerprints,
+        retirement_publication=publication,
+        lock_wait=lock_wait,
+    )
 
 
 def _publication_worker(store_path, retained, ready, start, output):
@@ -158,9 +131,7 @@ def test_older_completion_cannot_remove_newer_publication(tmp_path, monkeypatch)
     first = _publish(store_path, store)
     second = _publish(store_path, store)
 
-    _assert_conditional_finish_refusal(
-        _finish_retirement(store_path, first)
-    )
+    assert _finish_retirement(store_path, first) is False
     record = retirements.pending_retirement(str(store_path), "local", "old")
     assert record is not None
     publication_id = record.get("publication_id")
@@ -235,9 +206,7 @@ def test_completion_lock_failure_preserves_the_publication(
     publication = _publish(store_path, store)
     monkeypatch.setattr(retirements, "_acquire_fd", lambda *args, **kwargs: None)
 
-    _assert_conditional_finish_refusal(
-        _finish_retirement(store_path, publication)
-    )
+    assert _finish_retirement(store_path, publication) is False
     current = _current_retirement_record(store_path)
     assert current is not None
     publication_id = current.get("publication_id")
@@ -284,24 +253,25 @@ def test_final_gate_requires_the_exact_current_publication(tmp_path, monkeypatch
 def test_guarded_delete_cannot_adopt_a_replacement_publication(
     tmp_path, monkeypatch
 ):
+    """A receiptless guarded delete cannot borrow the slot's current authority.
+
+    Two publications land for the same retiring handle, so the slot holds the
+    replacement. A delete naming no receipt has no authority of its own and
+    must not adopt the one it happens to find: it conflicts, and the newer
+    publication survives untouched. Distinct from
+    ``test_guarded_delete_requires_a_current_publication``, where the slot is
+    empty and there is nothing to adopt.
+    """
     store_path, store = _pair(tmp_path, monkeypatch)
     _publish(store_path, store)
     current_publication = _publish(store_path, store)
 
-    try:
+    with pytest.raises(RetirementConflict):
         store.delete_index(
             "local",
             "old",
             expected_fingerprints=_fingerprints(store),
             lock_wait=True,
-        )
-    except RetirementConflict:
-        assert _supports_publication_receipts()
-    else:
-        assert not _supports_publication_receipts()
-        assert store.load_index("local", "old") is None
-        pytest.fail(
-            "receiptless guarded deletion adopted the replacement publication"
         )
 
     assert store.load_index("local", "old") is not None
@@ -394,9 +364,7 @@ def test_completion_unlink_failure_reports_retired_with_pending_cleanup(
 
     block = result["legacy_reconciliation"]
     assert block["reason_code"] == wc.REASON_LEGACY_RECONCILED
-    cleanup_schema = getattr(
-        storage_module, "RETIREMENT_CLEANUP_OUTCOME_SCHEMA", {}
-    )
+    cleanup_schema = storage_module.RETIREMENT_CLEANUP_OUTCOME_SCHEMA
     assert set(cleanup_schema) == {
         "retirement_cleanup_pending",
         "retirement_cleanup_record_state",
@@ -457,9 +425,7 @@ def test_conflict_cleanup_failure_uses_precommit_pending_signal(
     }
     assert block["reason_code"] == wc.REASON_LEGACY_CONFLICT
     assert block["pending_retirement"] is True
-    cleanup_schema = getattr(
-        storage_module, "RETIREMENT_CLEANUP_OUTCOME_SCHEMA", {}
-    )
+    cleanup_schema = storage_module.RETIREMENT_CLEANUP_OUTCOME_SCHEMA
     assert set(block).isdisjoint(cleanup_schema)
     record = retirements.pending_retirement(
         str(store_path), "local", "old"
@@ -664,16 +630,12 @@ def test_cross_process_older_cleanup_cannot_remove_winning_publication(
     assert record is not None
     winner = record.get("publication_id")
     if not isinstance(winner, str):
-        _assert_conditional_finish_refusal(
-            _finish_retirement(store_path, publications[0])
-        )
+        assert _finish_retirement(store_path, publications[0]) is False
         pytest.fail(
             "retirement completion lacked exact publication ownership"
         )
     loser = next(publication for publication in publications if publication != winner)
-    _assert_conditional_finish_refusal(
-        _finish_retirement(store_path, loser)
-    )
+    assert _finish_retirement(store_path, loser) is False
     current = retirements.pending_retirement(
         str(store_path), "local", "old"
     )

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -134,6 +134,43 @@ def test_unsafe_handles_fail_closed(tmp_path, monkeypatch, handle):
     assert retirements._fingerprint_handle(str(store_path), handle) is None
 
 
+def test_drive_relative_handle_never_escapes_the_store(tmp_path, monkeypatch):
+    """Windows drive-relative syntax is traversal without a separator.
+
+    ``C:..`` contains no separator and is neither ``.`` nor ``..``, so a
+    hand-rolled "no separators, no dots" rule admits it — but Windows resolves
+    it drive-relative, so the join walks out of the store and hashes whatever
+    it lands on. Only the canonical component policy rejects it.
+    """
+    store_path, _ = _pair(tmp_path, monkeypatch)
+    outside = store_path.parent / "escape.json"
+    outside.write_text("not part of this store", encoding="utf-8")
+
+    for handle in ("C:../escape", "D:/escape", "C:escape"):
+        assert retirements._fingerprint_handle(
+            str(store_path), handle
+        ) is None, f"{handle!r} produced a proof token"
+
+
+@pytest.mark.parametrize(
+    "component,safe",
+    [
+        ("modern", True), ("my.repo", True), ("a-b_c.1", True),
+        ("C:..", False), ("D:", False), ("..", False), ("."  , False),
+        ("", False), ("a/b", False), ("a\\b", False), (None, False),
+    ],
+)
+def test_component_policy_is_one_shared_rule(component, safe):
+    """Store side and record side must agree on what is safe to join."""
+    store = DocStore(base_path="unused")
+    assert retirements.is_safe_path_component(component) is safe
+    if safe:
+        assert store._safe_repo_component(component, "name") == component
+    else:
+        with pytest.raises(ValueError):
+            store._safe_repo_component(component, "name")
+
+
 def test_publication_receipt_is_unique_and_persisted(tmp_path, monkeypatch):
     store_path, store = _pair(tmp_path, monkeypatch)
 

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 import pytest
 
 from jdocmunch_mcp.storage import retirements
+from jdocmunch_mcp.storage import doc_store as storage_module
 from jdocmunch_mcp.storage.doc_store import DocStore, RetirementConflict
 from jdocmunch_mcp.tools import _worktree_corpus as wc
 from tests import test_v1_110_0 as legacy
@@ -302,8 +303,21 @@ def test_completion_unlink_failure_reports_retired_with_pending_cleanup(
 
     block = result["legacy_reconciliation"]
     assert block["reason_code"] == wc.REASON_LEGACY_RECONCILED
-    assert block["retirement_cleanup_pending"] is True
-    assert block["retirement_completion_marker_persisted"] is True
+    cleanup_schema = getattr(
+        storage_module, "RETIREMENT_CLEANUP_OUTCOME_SCHEMA", {}
+    )
+    assert set(cleanup_schema) == {
+        "retirement_cleanup_pending",
+        "retirement_completion_marker_persisted",
+        "retirement_cleanup_record_state",
+        "retirement_cleanup_owned",
+    }
+    assert {field: block[field] for field in cleanup_schema} == {
+        "retirement_cleanup_pending": True,
+        "retirement_completion_marker_persisted": True,
+        "retirement_cleanup_record_state": "readable",
+        "retirement_cleanup_owned": True,
+    }
     record = retirements.pending_retirement(
         str(store_path), "local", "old"
     )
@@ -350,8 +364,8 @@ def test_marker_persistence_failure_is_disclosed_from_durable_state(
 
     block = result["legacy_reconciliation"]
     assert block["reason_code"] == wc.REASON_LEGACY_RECONCILED
-    assert block["retirement_cleanup_pending"] is True
-    assert block["retirement_completion_marker_persisted"] is False
+    assert block.get("retirement_cleanup_pending") is True
+    assert block.get("retirement_completion_marker_persisted") is False
     record = retirements.pending_retirement(
         str(store_path), "local", "old"
     )
@@ -441,6 +455,9 @@ def test_reverse_scan_revalidates_candidate_under_its_lock(tmp_path, monkeypatch
     )
 
     assert replaced is True
+    assert record_path.exists(), (
+        "reverse scan removed a replacement retirement publication"
+    )
     current = json.loads(record_path.read_text(encoding="utf-8"))
     assert current["publication_id"] == replacement["publication_id"]
 

--- a/tests/test_issue95_qa19.py
+++ b/tests/test_issue95_qa19.py
@@ -341,13 +341,11 @@ def test_completion_unlink_failure_reports_retired_with_pending_cleanup(
     )
     assert set(cleanup_schema) == {
         "retirement_cleanup_pending",
-        "retirement_completion_marker_persisted",
         "retirement_cleanup_record_state",
         "retirement_cleanup_owned",
     }
     assert {field: block[field] for field in cleanup_schema} == {
         "retirement_cleanup_pending": True,
-        "retirement_completion_marker_persisted": True,
         "retirement_cleanup_record_state": "readable",
         "retirement_cleanup_owned": True,
     }
@@ -416,32 +414,29 @@ def test_conflict_cleanup_failure_uses_precommit_pending_signal(
     assert store.load_index("local", "modern") is not None
 
 
-def test_marker_persistence_failure_is_disclosed_from_durable_state(
+def test_unreadable_record_after_commit_is_disclosed_as_unowned(
     tmp_path, monkeypatch
 ):
+    """Disclosure reports OBSERVED durable state, not what the commit assumed.
+
+    The completion unlink fails and the record becomes unparseable in the same
+    step, so the emitter cannot confirm the publication it just completed. It
+    must say so — ``unreadable`` and not owned — rather than reporting the
+    publication identity it was holding in memory.
+    """
     _, worktree, _, store_path = legacy._standard_pair(
         tmp_path, monkeypatch
     )
     record_path = store_path / "local" / ".retirements" / "old.json"
     real_unlink = type(record_path).unlink
-    real_replace = retirements.os.replace
-    record_replacements = 0
 
-    def fail_record_unlink(path, *args, **kwargs):
+    def corrupt_then_fail_unlink(path, *args, **kwargs):
         if path == record_path:
+            path.write_text("{truncated", encoding="utf-8")
             raise OSError("injected publication completion failure")
         return real_unlink(path, *args, **kwargs)
 
-    def fail_marker_replace(source, destination, *args, **kwargs):
-        nonlocal record_replacements
-        if destination == record_path:
-            record_replacements += 1
-            if record_replacements > 1:
-                raise OSError("injected completion marker failure")
-        return real_replace(source, destination, *args, **kwargs)
-
-    monkeypatch.setattr(type(record_path), "unlink", fail_record_unlink)
-    monkeypatch.setattr(retirements.os, "replace", fail_marker_replace)
+    monkeypatch.setattr(type(record_path), "unlink", corrupt_then_fail_unlink)
 
     result = legacy._index(
         worktree / "docs",
@@ -452,13 +447,10 @@ def test_marker_persistence_failure_is_disclosed_from_durable_state(
 
     block = result["legacy_reconciliation"]
     assert block["reason_code"] == wc.REASON_LEGACY_RECONCILED
-    assert block.get("retirement_cleanup_pending") is True
-    assert block.get("retirement_completion_marker_persisted") is False
-    record = retirements.pending_retirement(
-        str(store_path), "local", "old"
-    )
-    assert record is not None
-    assert record.get("completion_pending") is not True
+    assert block["retirement_cleanup_pending"] is True
+    assert block["retirement_cleanup_record_state"] == "unreadable"
+    assert block["retirement_cleanup_owned"] is False
+    # The commit itself still stands: primary gone, retained peer intact.
     store = DocStore(base_path=str(store_path))
     assert store.load_index("local", "old") is None
     assert store.load_index("local", "modern") is not None

--- a/tests/test_issue95_qa19_interruption.py
+++ b/tests/test_issue95_qa19_interruption.py
@@ -1,0 +1,332 @@
+"""Real-process interruption recovery proofs for Issue #95 QA-19."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+from pathlib import Path
+
+from jdocmunch_mcp.storage import retirements
+from jdocmunch_mcp.storage.doc_store import DocStore, RetirementConflict
+from tests import test_v1_110_0 as legacy
+
+
+_PROCESS_TIMEOUT = 15
+_EXIT_AFTER_PUBLICATION = 91
+_EXIT_AFTER_PRIMARY = 92
+_EXIT_DURING_SELF_HEAL = 93
+
+
+def _record_path(store_path: str) -> Path:
+    return Path(store_path) / "local" / ".retirements" / "old.json"
+
+
+def _disk_state(store_path: str) -> dict:
+    record_path = _record_path(store_path)
+    return {
+        "primary_exists": (
+            Path(store_path) / "local" / "old.json"
+        ).is_file(),
+        "record": (
+            json.loads(record_path.read_text(encoding="utf-8"))
+            if record_path.is_file()
+            else None
+        ),
+    }
+
+
+def _fingerprints(store: DocStore, retained: str = "local/modern") -> dict:
+    return {
+        "local/old": store.index_fingerprint("local", "old"),
+        retained: store.index_fingerprint(*retained.split("/", 1)),
+    }
+
+
+def _publish(store_path: str, retained: str = "local/modern"):
+    store = DocStore(base_path=store_path)
+    return retirements.begin_retirement(
+        store_path,
+        "local",
+        "old",
+        retained=retained,
+        fingerprints=_fingerprints(store, retained),
+        family="qa19-interruption",
+    )
+
+
+def _trio(tmp_path, monkeypatch) -> tuple[Path, DocStore]:
+    _, _, _, store_path = legacy._standard_pair(tmp_path, monkeypatch)
+    store = DocStore(base_path=str(store_path))
+    store.save_index(
+        "local",
+        "next",
+        [],
+        {"next.md": "# Next\n"},
+        {".md": 1},
+    )
+    return store_path, store
+
+
+def _join(process, label: str, expected_exit: int = 0) -> None:
+    process.join(_PROCESS_TIMEOUT)
+    if process.is_alive():
+        process.terminate()
+        process.join(5)
+        raise AssertionError(f"{label} did not exit within {_PROCESS_TIMEOUT}s")
+    assert process.exitcode == expected_exit, (
+        f"{label} exit code {process.exitcode}, expected {expected_exit}"
+    )
+
+
+def _delete_from_record(store_path: str, output) -> None:
+    record = json.loads(_record_path(store_path).read_text(encoding="utf-8"))
+    store = DocStore(base_path=store_path)
+    kwargs = {
+        "expected_fingerprints": record["fingerprints"],
+        "lock_wait": True,
+    }
+    publication_id = record.get("publication_id")
+    if isinstance(publication_id, str):
+        kwargs["retirement_publication"] = publication_id
+    try:
+        output.put(("removed", store.delete_index("local", "old", **kwargs)))
+    except RetirementConflict as exc:
+        output.put(("conflict", str(exc)))
+
+
+def _pending_reader(store_path: str, output) -> None:
+    output.put(
+        retirements.pending_retirement(store_path, "local", "old")
+    )
+
+
+def _crash_after_publication(store_path: str, published) -> None:
+    assert _publish(store_path)
+    assert _record_path(store_path).is_file()
+    published.set()
+    os._exit(_EXIT_AFTER_PUBLICATION)
+
+
+def _crash_after_primary_delete(store_path: str, deleted) -> None:
+    store = DocStore(base_path=store_path)
+    fingerprints = _fingerprints(store)
+    publication = retirements.begin_retirement(
+        store_path,
+        "local",
+        "old",
+        retained="local/modern",
+        fingerprints=fingerprints,
+        family="qa19-interruption",
+    )
+    assert publication
+    original_finish = retirements.finish_retirement
+
+    def exit_before_completion(*args, **kwargs):
+        assert store.load_index("local", "old") is None
+        assert _record_path(store_path).is_file()
+        deleted.set()
+        os._exit(_EXIT_AFTER_PRIMARY)
+
+    retirements.finish_retirement = exit_before_completion
+    try:
+        kwargs = {
+            "expected_fingerprints": fingerprints,
+            "lock_wait": True,
+        }
+        if isinstance(publication, str):
+            kwargs["retirement_publication"] = publication
+        store.delete_index("local", "old", **kwargs)
+    finally:
+        retirements.finish_retirement = original_finish
+
+
+def _crash_during_self_heal(store_path: str, entered) -> None:
+    original_unlink = Path.unlink
+    record_path = _record_path(store_path)
+
+    def exit_before_record_unlink(path, *args, **kwargs):
+        if path == record_path:
+            assert record_path.is_file()
+            entered.set()
+            os._exit(_EXIT_DURING_SELF_HEAL)
+        return original_unlink(path, *args, **kwargs)
+
+    Path.unlink = exit_before_record_unlink
+    try:
+        retirements.pending_retirement(store_path, "local", "old")
+    finally:
+        Path.unlink = original_unlink
+
+
+def _publish_competing_after_recreation(store_path: str, output) -> None:
+    store = DocStore(base_path=store_path)
+    store.save_index(
+        "local",
+        "old",
+        [],
+        {"old.md": "# Recreated\n"},
+        {".md": 1},
+    )
+    publication = _publish(store_path, retained="local/next")
+    output.put(publication)
+
+
+def _finish_older_publication(
+    store_path: str, older_publication, output
+) -> None:
+    if isinstance(older_publication, str):
+        removed = retirements.finish_retirement(
+            store_path,
+            "local",
+            "old",
+            publication_id=older_publication,
+        )
+    else:
+        removed = retirements.finish_retirement(
+            store_path, "local", "old"
+        )
+    output.put(removed)
+
+
+def test_spawn_interrupt_after_publication_is_discoverable_and_retryable(
+    tmp_path, monkeypatch
+):
+    store_path, store = _trio(tmp_path, monkeypatch)
+    context = multiprocessing.get_context("spawn")
+    published = context.Event()
+    interrupted = context.Process(
+        target=_crash_after_publication,
+        args=(str(store_path), published),
+    )
+
+    interrupted.start()
+    assert published.wait(_PROCESS_TIMEOUT)
+    _join(
+        interrupted,
+        "pre-delete retirement",
+        expected_exit=_EXIT_AFTER_PUBLICATION,
+    )
+
+    state = _disk_state(str(store_path))
+    assert state["primary_exists"] is True
+    assert state["record"]["retained"] == "local/modern"
+
+    pending_output = context.Queue()
+    pending_reader = context.Process(
+        target=_pending_reader,
+        args=(str(store_path), pending_output),
+    )
+    pending_reader.start()
+    _join(pending_reader, "fresh pending reader")
+    assert pending_output.get(timeout=5)["retained"] == "local/modern"
+
+    retry_output = context.Queue()
+    retry = context.Process(
+        target=_delete_from_record,
+        args=(str(store_path), retry_output),
+    )
+    retry.start()
+    _join(retry, "fresh retirement retry")
+    assert retry_output.get(timeout=5) == ("removed", True)
+    assert store.load_index("local", "old") is None
+    assert _record_path(str(store_path)).exists() is False
+
+
+def test_spawn_interrupt_after_primary_is_not_falsely_pending(
+    tmp_path, monkeypatch
+):
+    store_path, store = _trio(tmp_path, monkeypatch)
+    context = multiprocessing.get_context("spawn")
+    deleted = context.Event()
+    interrupted = context.Process(
+        target=_crash_after_primary_delete,
+        args=(str(store_path), deleted),
+    )
+
+    interrupted.start()
+    assert deleted.wait(_PROCESS_TIMEOUT)
+    _join(
+        interrupted,
+        "post-primary retirement",
+        expected_exit=_EXIT_AFTER_PRIMARY,
+    )
+
+    state = _disk_state(str(store_path))
+    assert state["primary_exists"] is False
+    assert state["record"]["retained"] == "local/modern"
+
+    pending_output = context.Queue()
+    recovery = context.Process(
+        target=_pending_reader,
+        args=(str(store_path), pending_output),
+    )
+    recovery.start()
+    _join(recovery, "fresh completion recovery")
+    assert pending_output.get(timeout=5) is None
+    assert store.load_index("local", "old") is None
+    assert _record_path(str(store_path)).exists() is False
+
+
+def test_spawn_interrupted_self_heal_cannot_remove_new_publication(
+    tmp_path, monkeypatch
+):
+    store_path, _ = _trio(tmp_path, monkeypatch)
+    older_publication = _publish(str(store_path))
+    older_state = _disk_state(str(store_path))
+    older_identity = older_state["record"].get("publication_id")
+    if isinstance(older_identity, str):
+        older_publication = older_identity
+    (store_path / "local" / "old.json").unlink()
+
+    context = multiprocessing.get_context("spawn")
+    entered = context.Event()
+    interrupted = context.Process(
+        target=_crash_during_self_heal,
+        args=(str(store_path), entered),
+    )
+    interrupted.start()
+    assert entered.wait(_PROCESS_TIMEOUT)
+    _join(
+        interrupted,
+        "interrupted self-heal",
+        expected_exit=_EXIT_DURING_SELF_HEAL,
+    )
+
+    interrupted_state = _disk_state(str(store_path))
+    assert interrupted_state["primary_exists"] is False
+    assert interrupted_state["record"]["retained"] == "local/modern"
+
+    publish_output = context.Queue()
+    publisher = context.Process(
+        target=_publish_competing_after_recreation,
+        args=(str(store_path), publish_output),
+    )
+    publisher.start()
+    _join(publisher, "competing publisher")
+    assert publish_output.get(timeout=5)
+    newer_state = _disk_state(str(store_path))
+    assert newer_state["primary_exists"] is True
+    assert newer_state["record"]["retained"] == "local/next"
+
+    cleanup_output = context.Queue()
+    older_cleanup = context.Process(
+        target=_finish_older_publication,
+        args=(str(store_path), older_publication, cleanup_output),
+    )
+    older_cleanup.start()
+    _join(older_cleanup, "older cleanup retry")
+    cleanup_result = cleanup_output.get(timeout=5)
+
+    final_output = context.Queue()
+    final_reader = context.Process(
+        target=_pending_reader,
+        args=(str(store_path), final_output),
+    )
+    final_reader.start()
+    _join(final_reader, "fresh final-state reader")
+    final_record = final_output.get(timeout=5)
+    assert final_record is not None
+    assert final_record["retained"] == "local/next"
+    assert final_record == newer_state["record"]
+    assert cleanup_result is False

--- a/tests/test_issue95_qa19_process.py
+++ b/tests/test_issue95_qa19_process.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import multiprocessing
 import os
@@ -72,14 +73,16 @@ def _guarded_delete_worker(
 ) -> None:
     owner, name = retiring.split("/", 1)
     store = DocStore(base_path=store_path)
+    kwargs = {
+        "expected_fingerprints": fingerprints,
+        "lock_wait": True,
+    }
+    if "retirement_publication" in inspect.signature(
+        DocStore.delete_index
+    ).parameters:
+        kwargs["retirement_publication"] = publication
     try:
-        removed = store.delete_index(
-            owner,
-            name,
-            expected_fingerprints=fingerprints,
-            retirement_publication=publication,
-            lock_wait=True,
-        )
+        removed = store.delete_index(owner, name, **kwargs)
     except RetirementConflict as exc:
         output.put(("conflict", str(exc)))
     else:

--- a/tests/test_issue95_qa19_process.py
+++ b/tests/test_issue95_qa19_process.py
@@ -26,10 +26,10 @@ def _fingerprints(store: DocStore, retiring: str, retained: str) -> dict:
 
 def _publish(
     store_path: Path, store: DocStore, retiring: str, retained: str
-) -> dict:
+) -> tuple[dict, str]:
     fingerprints = _fingerprints(store, retiring, retained)
     owner, name = retiring.split("/", 1)
-    assert retirements.begin_retirement(
+    publication = retirements.begin_retirement(
         str(store_path),
         owner,
         name,
@@ -37,7 +37,8 @@ def _publish(
         fingerprints=fingerprints,
         family="qa19-process",
     )
-    return fingerprints
+    assert publication
+    return fingerprints, publication
 
 
 def _trio(tmp_path, monkeypatch) -> tuple[Path, DocStore]:
@@ -66,6 +67,7 @@ def _guarded_delete_worker(
     store_path: str,
     retiring: str,
     fingerprints: dict,
+    publication: str,
     output,
 ) -> None:
     owner, name = retiring.split("/", 1)
@@ -75,6 +77,7 @@ def _guarded_delete_worker(
             owner,
             name,
             expected_fingerprints=fingerprints,
+            retirement_publication=publication,
             lock_wait=True,
         )
     except RetirementConflict as exc:
@@ -132,6 +135,7 @@ def _retained_writer_at_gate_worker(
 def _guarded_delete_paused_at_retained_gate_worker(
     store_path: str,
     fingerprints: dict,
+    publication: str,
     at_gate,
     changed,
     output,
@@ -153,6 +157,7 @@ def _guarded_delete_paused_at_retained_gate_worker(
             store_path,
             "local/old",
             fingerprints,
+            publication,
             output,
         )
     finally:
@@ -162,6 +167,7 @@ def _guarded_delete_paused_at_retained_gate_worker(
 def _guarded_delete_paused_before_gate_worker(
     store_path: str,
     fingerprints: dict,
+    publication: str,
     before_gate,
     resume,
     output,
@@ -184,6 +190,7 @@ def _guarded_delete_paused_before_gate_worker(
             store_path,
             "local/old",
             fingerprints,
+            publication,
             output,
         )
     finally:
@@ -193,7 +200,7 @@ def _guarded_delete_paused_before_gate_worker(
 def test_spawn_retained_writer_gate_refuses_promptly(tmp_path, monkeypatch):
     """An in-flight retained writer makes final authorization fail closed."""
     store_path, store = _trio(tmp_path, monkeypatch)
-    fingerprints = _publish(
+    fingerprints, publication = _publish(
         store_path, store, "local/old", "local/modern"
     )
     context = multiprocessing.get_context("spawn")
@@ -211,6 +218,7 @@ def test_spawn_retained_writer_gate_refuses_promptly(tmp_path, monkeypatch):
             str(store_path),
             "local/old",
             fingerprints,
+            publication,
             delete_output,
         ),
     )
@@ -237,7 +245,7 @@ def test_spawn_writer_change_is_reproved_after_retained_gate(
 ):
     """A retained write landing before gate acquisition invalidates authority."""
     store_path, store = _trio(tmp_path, monkeypatch)
-    fingerprints = _publish(
+    fingerprints, publication = _publish(
         store_path, store, "local/old", "local/modern"
     )
     context = multiprocessing.get_context("spawn")
@@ -254,6 +262,7 @@ def test_spawn_writer_change_is_reproved_after_retained_gate(
         args=(
             str(store_path),
             fingerprints,
+            publication,
             at_gate,
             changed,
             delete_output,
@@ -277,10 +286,10 @@ def test_spawn_overlapping_chain_fails_closed_before_a_commit(
 ):
     """B-to-C removing B before A's commit invalidates A-to-B."""
     store_path, store = _trio(tmp_path, monkeypatch)
-    a_fingerprints = _publish(
+    a_fingerprints, a_publication = _publish(
         store_path, store, "local/old", "local/modern"
     )
-    b_fingerprints = _publish(
+    b_fingerprints, b_publication = _publish(
         store_path, store, "local/modern", "local/next"
     )
     context = multiprocessing.get_context("spawn")
@@ -293,6 +302,7 @@ def test_spawn_overlapping_chain_fails_closed_before_a_commit(
         args=(
             str(store_path),
             a_fingerprints,
+            a_publication,
             before_gate,
             resume,
             a_output,
@@ -304,6 +314,7 @@ def test_spawn_overlapping_chain_fails_closed_before_a_commit(
             str(store_path),
             "local/modern",
             b_fingerprints,
+            b_publication,
             b_output,
         ),
     )
@@ -329,7 +340,7 @@ def test_spawn_sequential_chain_allows_later_retirement(
     store_path, store = _trio(tmp_path, monkeypatch)
     context = multiprocessing.get_context("spawn")
     a_output = context.Queue()
-    a_fingerprints = _publish(
+    a_fingerprints, a_publication = _publish(
         store_path, store, "local/old", "local/modern"
     )
     retiring_a = context.Process(
@@ -338,6 +349,7 @@ def test_spawn_sequential_chain_allows_later_retirement(
             str(store_path),
             "local/old",
             a_fingerprints,
+            a_publication,
             a_output,
         ),
     )
@@ -349,7 +361,7 @@ def test_spawn_sequential_chain_allows_later_retirement(
     assert store.load_index("local", "modern") is not None
 
     b_output = context.Queue()
-    b_fingerprints = _publish(
+    b_fingerprints, b_publication = _publish(
         store_path, store, "local/modern", "local/next"
     )
     retiring_b = context.Process(
@@ -358,6 +370,7 @@ def test_spawn_sequential_chain_allows_later_retirement(
             str(store_path),
             "local/modern",
             b_fingerprints,
+            b_publication,
             b_output,
         ),
     )

--- a/tests/test_issue95_qa19_process.py
+++ b/tests/test_issue95_qa19_process.py
@@ -1,0 +1,369 @@
+"""Portable cross-process proofs for Issue #95 QA-19 commit authority."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+from contextlib import contextmanager
+from pathlib import Path
+
+from jdocmunch_mcp.storage import doc_store as doc_store_module
+from jdocmunch_mcp.storage import retirements
+from jdocmunch_mcp.storage.doc_store import DocStore, RetirementConflict
+from tests import test_v1_110_0 as legacy
+
+
+_PROCESS_TIMEOUT = 15
+
+
+def _fingerprints(store: DocStore, retiring: str, retained: str) -> dict:
+    return {
+        retiring: store.index_fingerprint(*retiring.split("/", 1)),
+        retained: store.index_fingerprint(*retained.split("/", 1)),
+    }
+
+
+def _publish(
+    store_path: Path, store: DocStore, retiring: str, retained: str
+) -> dict:
+    fingerprints = _fingerprints(store, retiring, retained)
+    owner, name = retiring.split("/", 1)
+    assert retirements.begin_retirement(
+        str(store_path),
+        owner,
+        name,
+        retained=retained,
+        fingerprints=fingerprints,
+        family="qa19-process",
+    )
+    return fingerprints
+
+
+def _trio(tmp_path, monkeypatch) -> tuple[Path, DocStore]:
+    _, _, _, store_path = legacy._standard_pair(tmp_path, monkeypatch)
+    store = DocStore(base_path=str(store_path))
+    store.save_index(
+        "local",
+        "next",
+        [],
+        {"next.md": "# Next\n"},
+        {".md": 1},
+    )
+    return store_path, store
+
+
+def _join(process, label: str, timeout: int = _PROCESS_TIMEOUT) -> None:
+    process.join(timeout)
+    if process.is_alive():
+        process.terminate()
+        process.join(5)
+        raise AssertionError(f"{label} did not exit within {timeout}s")
+    assert process.exitcode == 0, f"{label} exit code: {process.exitcode}"
+
+
+def _guarded_delete_worker(
+    store_path: str,
+    retiring: str,
+    fingerprints: dict,
+    output,
+) -> None:
+    owner, name = retiring.split("/", 1)
+    store = DocStore(base_path=store_path)
+    try:
+        removed = store.delete_index(
+            owner,
+            name,
+            expected_fingerprints=fingerprints,
+            lock_wait=True,
+        )
+    except RetirementConflict as exc:
+        output.put(("conflict", str(exc)))
+    else:
+        output.put(("removed" if removed else "not_removed", ()))
+
+
+def _retained_writer_worker(
+    store_path: str,
+    locked,
+    release,
+    output,
+) -> None:
+    store = DocStore(base_path=store_path)
+    path = store._index_path("local", "modern")
+    with store._index_write_lock("local", "modern"):
+        locked.set()
+        if not release.wait(_PROCESS_TIMEOUT):
+            raise TimeoutError("retained writer was not released")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["indexed_at"] = "qa19-cross-process-change"
+        temp = path.with_name(f"{path.name}.{os.getpid()}.qa19.tmp")
+        temp.write_text(
+            json.dumps(data, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        os.replace(temp, path)
+        output.put("changed")
+
+
+def _retained_writer_at_gate_worker(
+    store_path: str,
+    at_gate,
+    changed,
+    output,
+) -> None:
+    if not at_gate.wait(_PROCESS_TIMEOUT):
+        raise TimeoutError("retirement did not reach the retained gate")
+    store = DocStore(base_path=store_path)
+    path = store._index_path("local", "modern")
+    with store._index_write_lock("local", "modern"):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["indexed_at"] = "qa19-change-before-final-proof"
+        temp = path.with_name(f"{path.name}.{os.getpid()}.qa19.tmp")
+        temp.write_text(
+            json.dumps(data, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        os.replace(temp, path)
+    output.put("changed")
+    changed.set()
+
+
+def _guarded_delete_paused_at_retained_gate_worker(
+    store_path: str,
+    fingerprints: dict,
+    at_gate,
+    changed,
+    output,
+) -> None:
+    original_try_lock = DocStore._try_index_write_lock
+
+    @contextmanager
+    def pause_before_retained_gate(self, owner, name):
+        if (owner, name) == ("local", "modern"):
+            at_gate.set()
+            if not changed.wait(_PROCESS_TIMEOUT):
+                raise TimeoutError("retained writer did not finish")
+        with original_try_lock(self, owner, name) as acquired:
+            yield acquired
+
+    DocStore._try_index_write_lock = pause_before_retained_gate
+    try:
+        _guarded_delete_worker(
+            store_path,
+            "local/old",
+            fingerprints,
+            output,
+        )
+    finally:
+        DocStore._try_index_write_lock = original_try_lock
+
+
+def _guarded_delete_paused_before_gate_worker(
+    store_path: str,
+    fingerprints: dict,
+    before_gate,
+    resume,
+    output,
+) -> None:
+    store = DocStore(base_path=store_path)
+    retiring_content = store._content_dir("local", "old")
+    original_rmtree = doc_store_module.shutil.rmtree
+
+    def pause_after_auxiliary_removal(path, *args, **kwargs):
+        result = original_rmtree(path, *args, **kwargs)
+        if Path(path) == retiring_content:
+            before_gate.set()
+            if not resume.wait(_PROCESS_TIMEOUT):
+                raise TimeoutError("retiring delete was not resumed")
+        return result
+
+    doc_store_module.shutil.rmtree = pause_after_auxiliary_removal
+    try:
+        _guarded_delete_worker(
+            store_path,
+            "local/old",
+            fingerprints,
+            output,
+        )
+    finally:
+        doc_store_module.shutil.rmtree = original_rmtree
+
+
+def test_spawn_retained_writer_gate_refuses_promptly(tmp_path, monkeypatch):
+    """An in-flight retained writer makes final authorization fail closed."""
+    store_path, store = _trio(tmp_path, monkeypatch)
+    fingerprints = _publish(
+        store_path, store, "local/old", "local/modern"
+    )
+    context = multiprocessing.get_context("spawn")
+    locked = context.Event()
+    release = context.Event()
+    writer_output = context.Queue()
+    delete_output = context.Queue()
+    writer = context.Process(
+        target=_retained_writer_worker,
+        args=(str(store_path), locked, release, writer_output),
+    )
+    deleting = context.Process(
+        target=_guarded_delete_worker,
+        args=(
+            str(store_path),
+            "local/old",
+            fingerprints,
+            delete_output,
+        ),
+    )
+
+    writer.start()
+    assert locked.wait(_PROCESS_TIMEOUT)
+    deleting.start()
+    try:
+        _join(deleting, "retiring delete", timeout=5)
+        status, changed = delete_output.get(timeout=5)
+        assert status == "conflict"
+        assert "local/modern" in changed
+    finally:
+        release.set()
+        _join(writer, "retained writer")
+
+    assert writer_output.get(timeout=5) == "changed"
+    assert store.load_index("local", "old") is not None
+    assert store.load_index("local", "modern") is not None
+
+
+def test_spawn_writer_change_is_reproved_after_retained_gate(
+    tmp_path, monkeypatch
+):
+    """A retained write landing before gate acquisition invalidates authority."""
+    store_path, store = _trio(tmp_path, monkeypatch)
+    fingerprints = _publish(
+        store_path, store, "local/old", "local/modern"
+    )
+    context = multiprocessing.get_context("spawn")
+    at_gate = context.Event()
+    changed = context.Event()
+    writer_output = context.Queue()
+    delete_output = context.Queue()
+    writer = context.Process(
+        target=_retained_writer_at_gate_worker,
+        args=(str(store_path), at_gate, changed, writer_output),
+    )
+    deleting = context.Process(
+        target=_guarded_delete_paused_at_retained_gate_worker,
+        args=(
+            str(store_path),
+            fingerprints,
+            at_gate,
+            changed,
+            delete_output,
+        ),
+    )
+
+    writer.start()
+    deleting.start()
+    _join(writer, "retained writer")
+    _join(deleting, "retiring delete")
+
+    assert writer_output.get(timeout=5) == "changed"
+    status, detail = delete_output.get(timeout=5)
+    assert status == "conflict", detail
+    assert store.load_index("local", "old") is not None
+    assert store.load_index("local", "modern") is not None
+
+
+def test_spawn_overlapping_chain_fails_closed_before_a_commit(
+    tmp_path, monkeypatch
+):
+    """B-to-C removing B before A's commit invalidates A-to-B."""
+    store_path, store = _trio(tmp_path, monkeypatch)
+    a_fingerprints = _publish(
+        store_path, store, "local/old", "local/modern"
+    )
+    b_fingerprints = _publish(
+        store_path, store, "local/modern", "local/next"
+    )
+    context = multiprocessing.get_context("spawn")
+    before_gate = context.Event()
+    resume = context.Event()
+    a_output = context.Queue()
+    b_output = context.Queue()
+    retiring_a = context.Process(
+        target=_guarded_delete_paused_before_gate_worker,
+        args=(
+            str(store_path),
+            a_fingerprints,
+            before_gate,
+            resume,
+            a_output,
+        ),
+    )
+    retiring_b = context.Process(
+        target=_guarded_delete_worker,
+        args=(
+            str(store_path),
+            "local/modern",
+            b_fingerprints,
+            b_output,
+        ),
+    )
+
+    retiring_a.start()
+    assert before_gate.wait(_PROCESS_TIMEOUT)
+    retiring_b.start()
+    _join(retiring_b, "B-to-C retirement")
+    assert b_output.get(timeout=5)[0] == "removed"
+    assert store.load_index("local", "modern") is None
+    assert store.load_index("local", "next") is not None
+
+    resume.set()
+    _join(retiring_a, "A-to-B retirement")
+    assert a_output.get(timeout=5)[0] == "conflict"
+    assert store.load_index("local", "old") is not None
+
+
+def test_spawn_sequential_chain_allows_later_retirement(
+    tmp_path, monkeypatch
+):
+    """A-to-B commits with B loadable, then authorized B-to-C may retire B."""
+    store_path, store = _trio(tmp_path, monkeypatch)
+    context = multiprocessing.get_context("spawn")
+    a_output = context.Queue()
+    a_fingerprints = _publish(
+        store_path, store, "local/old", "local/modern"
+    )
+    retiring_a = context.Process(
+        target=_guarded_delete_worker,
+        args=(
+            str(store_path),
+            "local/old",
+            a_fingerprints,
+            a_output,
+        ),
+    )
+
+    retiring_a.start()
+    _join(retiring_a, "A-to-B retirement")
+    assert a_output.get(timeout=5)[0] == "removed"
+    assert store.load_index("local", "old") is None
+    assert store.load_index("local", "modern") is not None
+
+    b_output = context.Queue()
+    b_fingerprints = _publish(
+        store_path, store, "local/modern", "local/next"
+    )
+    retiring_b = context.Process(
+        target=_guarded_delete_worker,
+        args=(
+            str(store_path),
+            "local/modern",
+            b_fingerprints,
+            b_output,
+        ),
+    )
+    retiring_b.start()
+    _join(retiring_b, "B-to-C retirement")
+
+    assert b_output.get(timeout=5)[0] == "removed"
+    assert store.load_index("local", "modern") is None
+    assert store.load_index("local", "next") is not None

--- a/tests/test_issue95_qa20_vocabulary.py
+++ b/tests/test_issue95_qa20_vocabulary.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import importlib
+import multiprocessing
 from pathlib import Path
-
-import pytest
 
 
 delete_tool = importlib.import_module("jdocmunch_mcp.tools.delete_index")
+storage_module = importlib.import_module(
+    "jdocmunch_mcp.storage.doc_store"
+)
+DocStore = storage_module.DocStore
 
 SPEC_PATH = Path(__file__).parents[1] / "SPEC.md"
 TABLE_HEADING = "##### Public result vocabulary"
@@ -40,6 +43,59 @@ EXPECTED_MESSAGES = {
         "retry shortly."
     ),
 }
+
+EXPECTED_STORAGE_CODES = {
+    "deleted": "index_deleted",
+    "not_found": "index_not_found",
+    "lifecycle_busy": "index_lifecycle_busy",
+}
+
+
+def _store_with_index(storage_path):
+    store = DocStore(base_path=str(storage_path))
+    store.save_index(
+        "local",
+        "docs",
+        [],
+        {"docs.md": "# Docs\n"},
+        {".md": 1},
+    )
+    return store
+
+
+def _hold_index_lock(storage_path, locked, release):
+    store = DocStore(base_path=storage_path)
+    with store._index_write_lock("local", "docs"):
+        locked.set()
+        if not release.wait(15):
+            raise TimeoutError("index-lock holder was not released")
+
+
+def _join(process, label):
+    process.join(15)
+    if process.is_alive():
+        process.terminate()
+        process.join(5)
+        raise AssertionError(f"{label} did not exit")
+    assert process.exitcode == 0, f"{label} exit code: {process.exitcode}"
+
+
+def _contended_index(storage_path):
+    context = multiprocessing.get_context("spawn")
+    locked = context.Event()
+    release = context.Event()
+    holder = context.Process(
+        target=_hold_index_lock,
+        args=(str(storage_path), locked, release),
+    )
+    holder.start()
+    assert locked.wait(15)
+    return holder, release
+
+
+def _release_holder(holder, release):
+    release.set()
+    _join(holder, "index-lock holder")
 
 
 def _table_cells(line):
@@ -79,54 +135,91 @@ def test_runtime_vocabulary_is_complete_and_exact():
     assert delete_tool.DELETE_RESULT_VOCABULARY == EXPECTED_VOCABULARY
 
 
+def test_storage_reason_codes_are_the_public_source_of_truth():
+    assert storage_module.DELETE_REASON_CODES == EXPECTED_STORAGE_CODES
+    assert delete_tool.DELETE_REASON_CODES is storage_module.DELETE_REASON_CODES
+    assert set(delete_tool.DELETE_RESULT_VOCABULARY) == set(
+        storage_module.DELETE_REASON_CODES.values()
+    )
+
+
 def test_spec_table_exactly_matches_runtime_vocabulary():
     assert _published_vocabulary() == delete_tool.DELETE_RESULT_VOCABULARY
 
 
-@pytest.mark.parametrize(
-    ("reason_code", "success"),
-    [
-        ("index_deleted", True),
-        ("index_not_found", False),
-        ("index_lifecycle_busy", False),
-    ],
-)
-def test_public_delete_emits_each_authoritative_result(
-    tmp_path, monkeypatch, reason_code, success
-):
-    def resolve_repo(self, repo):
-        return "local", "docs"
+def test_real_storage_emitter_exercises_every_authoritative_result(tmp_path):
+    store = _store_with_index(tmp_path)
+    holder, release = _contended_index(tmp_path)
+    busy_outcome = {}
+    try:
+        assert store.delete_index(
+            "local",
+            "docs",
+            outcome=busy_outcome,
+            lock_wait=False,
+        ) is False
+    finally:
+        _release_holder(holder, release)
 
-    def delete_index(self, owner, name, *, outcome, lock_wait):
-        assert (owner, name) == ("local", "docs")
-        assert lock_wait is False
-        outcome["reason_code"] = reason_code
-        return success
+    deleted_outcome = {}
+    assert store.delete_index(
+        "local",
+        "docs",
+        outcome=deleted_outcome,
+        lock_wait=False,
+    ) is True
+    missing_outcome = {}
+    assert store.delete_index(
+        "local",
+        "docs",
+        outcome=missing_outcome,
+        lock_wait=False,
+    ) is False
 
-    monkeypatch.setattr(delete_tool.DocStore, "_resolve_repo", resolve_repo)
-    monkeypatch.setattr(delete_tool.DocStore, "delete_index", delete_index)
+    assert {
+        busy_outcome["reason_code"],
+        deleted_outcome["reason_code"],
+        missing_outcome["reason_code"],
+    } == set(EXPECTED_VOCABULARY)
+    assert busy_outcome["reason_code"] == EXPECTED_STORAGE_CODES[
+        "lifecycle_busy"
+    ]
+    assert deleted_outcome["reason_code"] == EXPECTED_STORAGE_CODES["deleted"]
+    assert missing_outcome["reason_code"] == EXPECTED_STORAGE_CODES["not_found"]
 
-    result = delete_tool.delete_index(
-        "local/docs",
-        storage_path=str(tmp_path),
+
+def test_public_delete_maps_every_real_storage_result(tmp_path):
+    _store_with_index(tmp_path)
+    holder, release = _contended_index(tmp_path)
+    try:
+        busy = delete_tool.delete_index(
+            "local/docs", storage_path=str(tmp_path)
+        )
+    finally:
+        _release_holder(holder, release)
+    deleted = delete_tool.delete_index(
+        "local/docs", storage_path=str(tmp_path)
+    )
+    missing = delete_tool.delete_index(
+        "local/docs", storage_path=str(tmp_path)
     )
 
-    assert set(result) == {
-        "success",
-        "repo",
-        "reason_code",
-        "retryable",
-        "message",
-        "_meta",
+    results = {
+        result["reason_code"]: result
+        for result in (busy, deleted, missing)
     }
-    assert {
-        "success": result["success"],
-        "reason_code": result["reason_code"],
-        "retryable": result["retryable"],
-    } == {
-        "success": EXPECTED_VOCABULARY[reason_code]["success"],
-        "reason_code": reason_code,
-        "retryable": EXPECTED_VOCABULARY[reason_code]["retryable"],
-    }
-    assert result["repo"] == "local/docs"
-    assert result["message"] == EXPECTED_MESSAGES[reason_code]
+    assert set(results) == set(EXPECTED_VOCABULARY)
+    for reason_code, expected in EXPECTED_VOCABULARY.items():
+        result = results[reason_code]
+        assert set(result) == {
+            "success",
+            "repo",
+            "reason_code",
+            "retryable",
+            "message",
+            "_meta",
+        }
+        assert result["success"] is expected["success"]
+        assert result["retryable"] is expected["retryable"]
+        assert result["repo"] == "local/docs"
+        assert result["message"] == EXPECTED_MESSAGES[reason_code]

--- a/tests/test_issue95_qa20_vocabulary.py
+++ b/tests/test_issue95_qa20_vocabulary.py
@@ -1,0 +1,132 @@
+"""Issue #95 QA-20 public delete-result vocabulary regressions."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+delete_tool = importlib.import_module("jdocmunch_mcp.tools.delete_index")
+
+SPEC_PATH = Path(__file__).parents[1] / "SPEC.md"
+TABLE_HEADING = "##### Public result vocabulary"
+TABLE_COLUMNS = ("Outcome", "success", "reason_code", "retryable")
+
+EXPECTED_VOCABULARY = {
+    "index_deleted": {
+        "outcome": "Deleted",
+        "success": True,
+        "retryable": False,
+    },
+    "index_not_found": {
+        "outcome": "Missing",
+        "success": False,
+        "retryable": False,
+    },
+    "index_lifecycle_busy": {
+        "outcome": "Lifecycle contention",
+        "success": False,
+        "retryable": True,
+    },
+}
+
+EXPECTED_MESSAGES = {
+    "index_deleted": "Index deleted.",
+    "index_not_found": "Index not found.",
+    "index_lifecycle_busy": (
+        "Index is busy completing a retirement. The index still exists; "
+        "retry shortly."
+    ),
+}
+
+
+def _table_cells(line):
+    return tuple(
+        cell.strip().strip("`")
+        for cell in line.strip().strip("|").split("|")
+    )
+
+
+def _published_vocabulary():
+    lines = SPEC_PATH.read_text(encoding="utf-8").splitlines()
+    assert TABLE_HEADING in lines, (
+        f"SPEC.md must contain the deliberate {TABLE_HEADING!r} schema"
+    )
+    heading_index = lines.index(TABLE_HEADING)
+    table_lines = []
+    for line in lines[heading_index + 1 :]:
+        if line.startswith("|"):
+            table_lines.append(line)
+        elif table_lines:
+            break
+
+    assert len(table_lines) == 5
+    assert _table_cells(table_lines[0]) == TABLE_COLUMNS
+    rows = {}
+    for line in table_lines[2:]:
+        outcome, success, reason_code, retryable = _table_cells(line)
+        rows[reason_code] = {
+            "outcome": outcome,
+            "success": {"true": True, "false": False}[success],
+            "retryable": {"true": True, "false": False}[retryable],
+        }
+    return rows
+
+
+def test_runtime_vocabulary_is_complete_and_exact():
+    assert delete_tool.DELETE_RESULT_VOCABULARY == EXPECTED_VOCABULARY
+
+
+def test_spec_table_exactly_matches_runtime_vocabulary():
+    assert _published_vocabulary() == delete_tool.DELETE_RESULT_VOCABULARY
+
+
+@pytest.mark.parametrize(
+    ("reason_code", "success"),
+    [
+        ("index_deleted", True),
+        ("index_not_found", False),
+        ("index_lifecycle_busy", False),
+    ],
+)
+def test_public_delete_emits_each_authoritative_result(
+    tmp_path, monkeypatch, reason_code, success
+):
+    def resolve_repo(self, repo):
+        return "local", "docs"
+
+    def delete_index(self, owner, name, *, outcome, lock_wait):
+        assert (owner, name) == ("local", "docs")
+        assert lock_wait is False
+        outcome["reason_code"] = reason_code
+        return success
+
+    monkeypatch.setattr(delete_tool.DocStore, "_resolve_repo", resolve_repo)
+    monkeypatch.setattr(delete_tool.DocStore, "delete_index", delete_index)
+
+    result = delete_tool.delete_index(
+        "local/docs",
+        storage_path=str(tmp_path),
+    )
+
+    assert set(result) == {
+        "success",
+        "repo",
+        "reason_code",
+        "retryable",
+        "message",
+        "_meta",
+    }
+    assert {
+        "success": result["success"],
+        "reason_code": result["reason_code"],
+        "retryable": result["retryable"],
+    } == {
+        "success": EXPECTED_VOCABULARY[reason_code]["success"],
+        "reason_code": reason_code,
+        "retryable": EXPECTED_VOCABULARY[reason_code]["retryable"],
+    }
+    assert result["repo"] == "local/docs"
+    assert result["message"] == EXPECTED_MESSAGES[reason_code]

--- a/tests/test_issue95_qa20_vocabulary.py
+++ b/tests/test_issue95_qa20_vocabulary.py
@@ -132,14 +132,21 @@ def _published_vocabulary():
 
 
 def test_runtime_vocabulary_is_complete_and_exact():
-    assert delete_tool.DELETE_RESULT_VOCABULARY == EXPECTED_VOCABULARY
+    assert (
+        getattr(delete_tool, "DELETE_RESULT_VOCABULARY", None)
+        == EXPECTED_VOCABULARY
+    )
 
 
 def test_storage_reason_codes_are_the_public_source_of_truth():
-    assert storage_module.DELETE_REASON_CODES == EXPECTED_STORAGE_CODES
-    assert delete_tool.DELETE_REASON_CODES is storage_module.DELETE_REASON_CODES
-    assert set(delete_tool.DELETE_RESULT_VOCABULARY) == set(
-        storage_module.DELETE_REASON_CODES.values()
+    storage_codes = getattr(storage_module, "DELETE_REASON_CODES", None)
+    tool_codes = getattr(delete_tool, "DELETE_REASON_CODES", None)
+    vocabulary = getattr(delete_tool, "DELETE_RESULT_VOCABULARY", None)
+
+    assert storage_codes == EXPECTED_STORAGE_CODES
+    assert tool_codes is storage_codes
+    assert set(vocabulary) == set(
+        storage_codes.values()
     )
 
 

--- a/tests/test_issue95_qa23_qa21.py
+++ b/tests/test_issue95_qa23_qa21.py
@@ -1,0 +1,138 @@
+"""Issue #95 QA-23 wait-policy and QA-21 stable-lockfile regressions."""
+
+from __future__ import annotations
+
+import inspect
+import multiprocessing
+import threading
+import time
+
+from jdocmunch_mcp.storage import retirements
+from jdocmunch_mcp.storage.doc_store import DocStore
+from jdocmunch_mcp.tools.delete_index import delete_index as public_delete
+from tests import test_v1_110_0 as legacy
+
+
+def _pair(tmp_path, monkeypatch):
+    _, _, _, store_path = legacy._standard_pair(tmp_path, monkeypatch)
+    return store_path, DocStore(base_path=str(store_path))
+
+
+def _publish(store_path, store):
+    fingerprints = {
+        "local/old": store.index_fingerprint("local", "old"),
+        "local/modern": store.index_fingerprint("local", "modern"),
+    }
+    assert all(fingerprints.values())
+    assert retirements.begin_retirement(
+        str(store_path),
+        "local",
+        "old",
+        retained="local/modern",
+        fingerprints=fingerprints,
+        family="qa23",
+    )
+
+
+def _hold_record_lock(base_path, ready, release):
+    with retirements.hold_record_lock(base_path, "local", "old"):
+        ready.set()
+        if not release.wait(15):
+            raise TimeoutError("record-lock holder was not released")
+
+
+def _contended_record(store_path):
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    release = context.Event()
+    holder = context.Process(
+        target=_hold_record_lock,
+        args=(str(store_path), ready, release),
+    )
+    holder.start()
+    assert ready.wait(15)
+    return holder, release
+
+
+def _release_holder(holder, release):
+    release.set()
+    holder.join(15)
+    assert holder.exitcode == 0
+
+
+def test_public_record_lock_contention_returns_typed_busy_promptly(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    _publish(store_path, store)
+    holder, release = _contended_record(store_path)
+
+    started = time.perf_counter()
+    try:
+        result = public_delete(
+            "local/modern",
+            storage_path=str(store_path),
+        )
+        elapsed = time.perf_counter() - started
+    finally:
+        _release_holder(holder, release)
+
+    assert elapsed < 0.5
+    assert result["success"] is False
+    assert result["reason_code"] == "index_lifecycle_busy"
+    assert result["retryable"] is True
+    assert store.load_index("local", "modern") is not None
+
+
+def test_internal_record_lock_coordination_keeps_bounded_wait(
+    tmp_path, monkeypatch
+):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    _publish(store_path, store)
+    holder, release = _contended_record(store_path)
+    timer = threading.Timer(0.2, release.set)
+    outcome = {}
+
+    timer.start()
+    started = time.perf_counter()
+    try:
+        deleted = store.delete_index(
+            "local",
+            "modern",
+            outcome=outcome,
+            lock_wait=True,
+        )
+        elapsed = time.perf_counter() - started
+    finally:
+        timer.cancel()
+        _release_holder(holder, release)
+
+    assert elapsed >= 0.1
+    assert elapsed < 1.0
+    assert deleted is True
+    assert outcome["reason_code"] == "index_deleted"
+
+
+def test_wait_policy_defaults_remain_compatible():
+    delete_default = inspect.signature(DocStore.delete_index).parameters[
+        "lock_wait"
+    ]
+    helper_default = inspect.signature(
+        retirements.try_void_retirements_referencing
+    ).parameters["timeout_seconds"]
+
+    assert delete_default.default is False
+    assert helper_default.default == 1.0
+
+
+def test_successful_delete_preserves_stable_lockfile(tmp_path, monkeypatch):
+    store_path, store = _pair(tmp_path, monkeypatch)
+    lock_path = store._index_path("local", "old").with_name("old.json.lock")
+    with store._index_write_lock("local", "old"):
+        pass
+    before = lock_path.stat()
+
+    assert store.delete_index("local", "old", lock_wait=False) is True
+
+    after = lock_path.stat()
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -12,7 +12,8 @@ SECTION_END = '`legacy_reconcile="report"`'
 
 REQUIRED_CONTRACTS = {
     "exact publication authority": (
-        "a readable current retirement record with the exact current "
+        "requires the explicit publication receipt created by its caller and "
+        "a readable current retirement record with that exact current "
         "publication identity"
     ),
     "post-retained-gate proof": (
@@ -23,10 +24,18 @@ REQUIRED_CONTRACTS = {
         "stale or older cleanup cannot remove a newer publication"
     ),
     "truthful completion recovery": (
-        "failure after the primary unlink remains truthfully recoverable"
+        "after the primary unlink commits, the retirement result is retired"
     ),
-    "fresh-read self-healing": (
-        "a fresh pending-state read self-heals the completed deletion"
+    "additive cleanup disclosure": (
+        "record cleanup failure is disclosed additively on that retired result"
+    ),
+    "truthful self-healing": (
+        "a fresh pending-state read returns the durable record when self-healing "
+        "cannot remove it"
+    ),
+    "non-retired availability": (
+        "every non-retired outcome occurs before the primary unlink and leaves "
+        "the retiring monolith loadable"
     ),
     "commit-scoped availability": (
         "at the protected A-to-B commit, B is loadable"
@@ -64,6 +73,19 @@ def _assert_retirement_contract(spec_path=SPEC_PATH):
 
 def test_retirement_coordination_spec_matches_commit_contract():
     _assert_retirement_contract()
+
+
+def test_cleanup_incomplete_vocabulary_is_precommit_only():
+    section = _retirement_section()
+
+    assert (
+        "cleanup-incomplete reason codes describe only a pre-commit failure"
+        in section
+    )
+    assert (
+        "a cleanup-incomplete outcome never follows a committed primary unlink"
+        in section
+    )
 
 
 def test_retirement_conflict_docstring_scopes_availability_to_retiring_primary():

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -114,7 +114,9 @@ CLEANUP_INCOMPLETE_PATTERN = re.compile(
 CLEANUP_INCOMPLETE_PRECOMMIT_ONLY_PATTERN = re.compile(
     r"""
     \bcleanup[-_]incomplete\b
-    [^.!?;:]{0,160}?
+    (?:\s+(?:outcome|reason\s+codes?))?
+    \s+(?:occur(?:s|red|ring)?|return(?:s|ed|ing)?|describe(?:s|d)?)
+    [^.!?;:]{0,40}?
     (?:
         \bonly\s+(?:a\s+)?pre-commit\b
         |
@@ -129,7 +131,8 @@ CLEANUP_INCOMPLETE_PRECOMMIT_ONLY_PATTERN = re.compile(
 CLEANUP_INCOMPLETE_COMMITTED_UNLINK_PROHIBITION_PATTERN = re.compile(
     r"""
     \bcleanup[-_]incomplete\b
-    [^.!?;:]{0,160}?
+    (?:\s+(?:outcome|response|reason\s+codes?))?
+    \s+
     \b(?:never|cannot|can't|must\s+not|may\s+not|does\s+not|do\s+not)\b
     \s+(?:be\s+)?
     (?:
@@ -139,6 +142,59 @@ CLEANUP_INCOMPLETE_COMMITTED_UNLINK_PROHIBITION_PATTERN = re.compile(
         [^.!?;:]{0,80}?
         \b(?:after|following)\s+(?:a\s+)?committed\s+primary\s+unlink
     )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+CLEANUP_INCOMPLETE_LEADING_PRECOMMIT_ONLY_PATTERN = re.compile(
+    r"""
+    (?:
+        \bonly\s+(?:a\s+)?pre-commit\b
+        |
+        \bpre-commit[- ]only\b
+        |
+        \bonly\s+before\s+(?:the\s+)?primary\s+unlink\b
+    )
+    \s*,?\s+
+    (?:(?:may|can|does)\s+)?
+    \bcleanup[-_]incomplete\b
+    (?:\s+(?:outcome|response))?
+    \s+(?:(?:may|can|does)\s+)?
+    (?:occur(?:s|red|ring)?|return(?:s|ed|ing)?)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+CLEANUP_INCOMPLETE_LEADING_COMMITTED_UNLINK_PROHIBITION_PATTERN = re.compile(
+    r"""
+    \b(?:after|following)\s+(?:a\s+)?committed\s+primary\s+unlink\b
+    \s*,?\s+
+    \bcleanup[-_]incomplete\b
+    (?:\s+(?:outcome|response))?
+    \s+
+    \b(?:never|cannot|can't|must\s+not|may\s+not|does\s+not|do\s+not)\b
+    \s+(?:be\s+)?
+    (?:follow(?:s|ed|ing)?|occur(?:s|red|ring)?|return(?:s|ed|ing)?)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+CLEANUP_INCOMPLETE_RELATIONSHIP_PATTERNS = (
+    CLEANUP_INCOMPLETE_PRECOMMIT_ONLY_PATTERN,
+    CLEANUP_INCOMPLETE_COMMITTED_UNLINK_PROHIBITION_PATTERN,
+    CLEANUP_INCOMPLETE_LEADING_PRECOMMIT_ONLY_PATTERN,
+    CLEANUP_INCOMPLETE_LEADING_COMMITTED_UNLINK_PROHIBITION_PATTERN,
+)
+
+CLEANUP_INCOMPLETE_RELATIONSHIP_BOUNDARY_PATTERN = re.compile(
+    r"""
+    ;\s+
+    |
+    :\s+
+    |
+    ,\s+(?=(?:and|yet|or)\b)
+    |
+    (?:,\s*|\s+)(?:but|while|because)\s+
     """,
     re.IGNORECASE | re.VERBOSE,
 )
@@ -245,10 +301,8 @@ def _assert_cleanup_incomplete_accounted(section):
         normalized_paragraph = " ".join(paragraph.split())
         sentences = re.split(r"(?<=[.!?])\s+", normalized_paragraph)
         for sentence in sentences:
-            clauses = re.split(
-                r";\s+|:\s+|,\s+(?=(?:and|but|yet|or)\b)",
-                sentence,
-                flags=re.IGNORECASE,
+            clauses = CLEANUP_INCOMPLETE_RELATIONSHIP_BOUNDARY_PATTERN.split(
+                sentence
             )
             matching_units.extend(
                 clause.strip()
@@ -257,16 +311,20 @@ def _assert_cleanup_incomplete_accounted(section):
             )
     assert matching_units, "SPEC.md must publish cleanup-incomplete prose"
     for unit in matching_units:
-        relationship_is_bound = bool(
-            CLEANUP_INCOMPLETE_PRECOMMIT_ONLY_PATTERN.search(unit)
-            or CLEANUP_INCOMPLETE_COMMITTED_UNLINK_PROHIBITION_PATTERN.search(
-                unit
+        allowed_spans = [
+            match.span()
+            for pattern in CLEANUP_INCOMPLETE_RELATIONSHIP_PATTERNS
+            for match in pattern.finditer(unit)
+        ]
+        for occurrence in CLEANUP_INCOMPLETE_PATTERN.finditer(unit):
+            occurrence_is_bound = any(
+                start <= occurrence.start() and occurrence.end() <= end
+                for start, end in allowed_spans
             )
-        )
-        assert relationship_is_bound, (
-            "cleanup-incomplete prose occurrence is not independently "
-            f"accounted: {unit!r}"
-        )
+            assert occurrence_is_bound, (
+                "cleanup-incomplete prose occurrence is not independently "
+                f"accounted: {unit!r}"
+            )
 
 
 def _assert_retirement_contract(spec_path=SPEC_PATH):
@@ -385,6 +443,39 @@ def test_retirement_spec_accepts_only_before_primary_unlink():
     _assert_cleanup_incomplete_accounted(
         "Cleanup-incomplete occurs only before the primary unlink."
     )
+
+
+@pytest.mark.parametrize(
+    "contradiction",
+    (
+        (
+            "Cleanup_incomplete never follows a committed primary unlink but "
+            "cleanup_incomplete may return after a committed primary unlink."
+        ),
+        (
+            "Cleanup_incomplete may follow a committed primary unlink while "
+            "monitoring runs only before the primary unlink."
+        ),
+    ),
+)
+def test_retirement_spec_rejects_cross_occurrence_qualifiers(
+    contradiction,
+):
+    with pytest.raises(AssertionError, match="contains contradictions"):
+        _assert_no_contradictions(
+            _retirement_section_raw() + "\n" + contradiction
+        )
+
+
+@pytest.mark.parametrize(
+    "valid_claim",
+    (
+        "Only before the primary unlink may cleanup-incomplete occur.",
+        "After a committed primary unlink, cleanup_incomplete cannot occur.",
+    ),
+)
+def test_retirement_spec_accepts_leading_cleanup_qualifiers(valid_claim):
+    _assert_cleanup_incomplete_accounted(valid_claim)
 
 
 def test_retirement_conflict_docstring_scopes_availability_to_retiring_primary():

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -1,6 +1,9 @@
 """Issue #95 retirement coordination specification contract."""
 
+import inspect
 from pathlib import Path
+
+from jdocmunch_mcp.storage.doc_store import RetirementConflict
 
 
 SPEC_PATH = Path(__file__).parents[1] / "SPEC.md"
@@ -61,3 +64,10 @@ def _assert_retirement_contract(spec_path=SPEC_PATH):
 
 def test_retirement_coordination_spec_matches_commit_contract():
     _assert_retirement_contract()
+
+
+def test_retirement_conflict_docstring_scopes_availability_to_retiring_primary():
+    docstring = " ".join(inspect.getdoc(RetirementConflict).split()).lower()
+
+    assert "the retiring primary remains loadable" in docstring
+    assert "every participating index remains loadable" not in docstring

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -3,12 +3,17 @@
 import inspect
 from pathlib import Path
 
+import pytest
+
+from jdocmunch_mcp.storage import doc_store as storage_module
 from jdocmunch_mcp.storage.doc_store import RetirementConflict
 
 
 SPEC_PATH = Path(__file__).parents[1] / "SPEC.md"
 SECTION_START = "**Retirement coordination**"
 SECTION_END = '`legacy_reconcile="report"`'
+SCHEMA_HEADING = "##### Retirement cleanup disclosure schema"
+MATRIX_HEADING = "##### Retirement commit outcome matrix"
 
 REQUIRED_CONTRACTS = {
     "exact publication authority": (
@@ -50,12 +55,106 @@ REQUIRED_CONTRACTS = {
     ),
 }
 
+EXPECTED_OUTCOME_MATRIX = {
+    "Pre-commit refusal": {
+        "Primary unlink committed": "false",
+        "Returned retirement status": "non-retired",
+        "Retiring monolith": "loadable",
+        "Cleanup fields": "absent",
+        "Durable recovery": (
+            "Retry starts from the still-loadable retiring monolith."
+        ),
+    },
+    "Committed with complete record cleanup": {
+        "Primary unlink committed": "true",
+        "Returned retirement status": "retired",
+        "Retiring monolith": "absent",
+        "Cleanup fields": "absent",
+        "Durable recovery": (
+            "No retirement cleanup remains for that exact publication."
+        ),
+    },
+    "Committed with incomplete record cleanup": {
+        "Primary unlink committed": "true",
+        "Returned retirement status": "retired",
+        "Retiring monolith": "absent",
+        "Cleanup fields": "present",
+        "Durable recovery": (
+            "The four fields report durable state; a fresh pending read "
+            "self-heals or returns the record."
+        ),
+    },
+}
 
-def _retirement_section(spec_path=SPEC_PATH):
+FORBIDDEN_CONTRADICTIONS = (
+    "cleanup-incomplete may follow a committed primary unlink",
+    "cleanup-incomplete after committed unlink",
+    "a non-retired result may have an absent retiring monolith",
+    "non-retired result with an absent monolith",
+)
+
+
+def _retirement_section_raw(spec_path=SPEC_PATH):
     text = spec_path.read_text(encoding="utf-8")
     start = text.index(SECTION_START)
     end = text.index(SECTION_END, start)
-    return " ".join(text[start:end].split()).lower()
+    return text[start:end]
+
+
+def _retirement_section(spec_path=SPEC_PATH):
+    return " ".join(_retirement_section_raw(spec_path).split()).lower()
+
+
+def _parse_table(section, heading):
+    lines = section.splitlines()
+    assert heading in lines, f"SPEC.md must contain {heading!r}"
+    start = next(
+        index
+        for index in range(lines.index(heading) + 1, len(lines))
+        if lines[index].startswith("|")
+    )
+    headers = [
+        value.strip() for value in lines[start].strip("|").split("|")
+    ]
+    rows = {}
+    for line in lines[start + 2 :]:
+        if not line.startswith("|"):
+            break
+        values = [
+            value.strip().replace("`", "")
+            for value in line.strip("|").split("|")
+        ]
+        row = dict(zip(headers, values, strict=True))
+        rows[values[0]] = {
+            header: row[header] for header in headers[1:]
+        }
+    return rows
+
+
+def _published_cleanup_schema():
+    rows = _parse_table(_retirement_section_raw(), SCHEMA_HEADING)
+    return {
+        field: {
+            "json_type": row["JSON type"],
+            "allowed_values": tuple(
+                value.strip()
+                for value in row["Allowed values"].split(",")
+            ),
+            "meaning": row["Meaning"],
+        }
+        for field, row in rows.items()
+    }
+
+
+def _assert_no_contradictions(section):
+    normalized = " ".join(section.split()).lower()
+    contradictions = [
+        claim for claim in FORBIDDEN_CONTRADICTIONS if claim in normalized
+    ]
+    assert not contradictions, (
+        "SPEC.md retirement coordination contains contradictions: "
+        + ", ".join(contradictions)
+    )
 
 
 def _assert_retirement_contract(spec_path=SPEC_PATH):
@@ -69,6 +168,7 @@ def _assert_retirement_contract(spec_path=SPEC_PATH):
         "SPEC.md retirement coordination is missing contracts: "
         + ", ".join(missing)
     )
+    _assert_no_contradictions(section)
 
 
 def test_retirement_coordination_spec_matches_commit_contract():
@@ -86,6 +186,35 @@ def test_cleanup_incomplete_vocabulary_is_precommit_only():
         "a cleanup-incomplete outcome never follows a committed primary unlink"
         in section
     )
+
+
+def test_cleanup_disclosure_schema_matches_storage_emitter():
+    runtime_schema = getattr(
+        storage_module, "RETIREMENT_CLEANUP_OUTCOME_SCHEMA", None
+    )
+
+    assert runtime_schema is not None
+    assert _published_cleanup_schema() == runtime_schema
+
+
+def test_retirement_commit_outcome_matrix_is_complete_and_consistent():
+    rows = _parse_table(_retirement_section_raw(), MATRIX_HEADING)
+
+    assert rows == EXPECTED_OUTCOME_MATRIX
+    for row in rows.values():
+        committed = row["Primary unlink committed"] == "true"
+        if committed:
+            assert row["Returned retirement status"] == "retired"
+            assert row["Retiring monolith"] == "absent"
+        else:
+            assert row["Returned retirement status"] == "non-retired"
+            assert row["Retiring monolith"] == "loadable"
+
+
+@pytest.mark.parametrize("claim", FORBIDDEN_CONTRADICTIONS)
+def test_retirement_spec_rejects_explicit_contradictions(claim):
+    with pytest.raises(AssertionError, match="contains contradictions"):
+        _assert_no_contradictions(_retirement_section_raw() + "\n" + claim)
 
 
 def test_retirement_conflict_docstring_scopes_availability_to_retiring_primary():

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -1,6 +1,7 @@
 """Issue #95 retirement coordination specification contract."""
 
 import inspect
+import re
 from pathlib import Path
 
 import pytest
@@ -53,6 +54,9 @@ REQUIRED_CONTRACTS = {
         "public deletion uses zero-wait coordination, while internal "
         "retirement uses its bounded wait"
     ),
+    "pre-commit pending signal": (
+        "durable pre-commit recovery signal"
+    ),
 }
 
 EXPECTED_OUTCOME_MATRIX = {
@@ -86,11 +90,25 @@ EXPECTED_OUTCOME_MATRIX = {
     },
 }
 
-FORBIDDEN_CONTRADICTIONS = (
-    "cleanup-incomplete may follow a committed primary unlink",
-    "cleanup-incomplete after committed unlink",
+ABSENT_MONOLITH_CONTRADICTIONS = (
     "a non-retired result may have an absent retiring monolith",
     "non-retired result with an absent monolith",
+)
+
+CLEANUP_INCOMPLETE_CONTRADICTIONS = (
+    (
+        "Following a successful primary unlink, the operation can still "
+        "return cleanup_incomplete."
+    ),
+    (
+        "The primary index can be unlinked before a cleanup-incomplete "
+        "response is returned."
+    ),
+)
+
+CLEANUP_INCOMPLETE_PATTERN = re.compile(
+    r"\bcleanup[-_]incomplete\b",
+    re.IGNORECASE,
 )
 
 
@@ -149,12 +167,60 @@ def _published_cleanup_schema():
 def _assert_no_contradictions(section):
     normalized = " ".join(section.split()).lower()
     contradictions = [
-        claim for claim in FORBIDDEN_CONTRADICTIONS if claim in normalized
+        claim
+        for claim in ABSENT_MONOLITH_CONTRADICTIONS
+        if claim in normalized
     ]
     assert not contradictions, (
         "SPEC.md retirement coordination contains contradictions: "
         + ", ".join(contradictions)
     )
+    try:
+        _assert_cleanup_incomplete_accounted(section)
+    except AssertionError as exc:
+        raise AssertionError(
+            "SPEC.md retirement coordination contains contradictions: "
+            f"{exc}"
+        ) from exc
+
+
+def _assert_cleanup_incomplete_accounted(section):
+    matching_lines = [
+        line
+        for line in section.splitlines()
+        if CLEANUP_INCOMPLETE_PATTERN.search(line)
+    ]
+    assert matching_lines, "SPEC.md must publish cleanup-incomplete semantics"
+    for row in (line for line in matching_lines if line.startswith("|")):
+        cells = [
+            cell.strip().replace("`", "").lower()
+            for cell in row.strip("|").split("|")
+        ]
+        assert cells[0].endswith("cleanup_incomplete"), (
+            "cleanup-incomplete table occurrence is not a reason code"
+        )
+        assert "pre-commit" in cells[-1], (
+            "cleanup-incomplete table row is not pre-commit"
+        )
+        assert "prevented the primary unlink" in cells[-1], (
+            "cleanup-incomplete table row does not prevent unlink"
+        )
+    prose = "\n".join(
+        line for line in section.splitlines() if not line.startswith("|")
+    )
+    paragraphs = [
+        paragraph.strip()
+        for paragraph in re.split(r"\n\s*\n", prose)
+        if CLEANUP_INCOMPLETE_PATTERN.search(paragraph)
+    ]
+    for paragraph in paragraphs:
+        normalized = " ".join(paragraph.split()).lower()
+        assert "pre-commit" in normalized, (
+            "cleanup-incomplete prose is not explicitly pre-commit"
+        )
+        assert (
+            "never follows a committed primary unlink" in normalized
+        ), "cleanup-incomplete prose permits a committed unlink"
 
 
 def _assert_retirement_contract(spec_path=SPEC_PATH):
@@ -169,6 +235,9 @@ def _assert_retirement_contract(spec_path=SPEC_PATH):
         + ", ".join(missing)
     )
     _assert_no_contradictions(section)
+    _assert_cleanup_incomplete_accounted(
+        spec_path.read_text(encoding="utf-8")
+    )
 
 
 def test_retirement_coordination_spec_matches_commit_contract():
@@ -211,8 +280,15 @@ def test_retirement_commit_outcome_matrix_is_complete_and_consistent():
             assert row["Retiring monolith"] == "loadable"
 
 
-@pytest.mark.parametrize("claim", FORBIDDEN_CONTRADICTIONS)
+@pytest.mark.parametrize(
+    "claim",
+    (
+        *ABSENT_MONOLITH_CONTRADICTIONS,
+        *CLEANUP_INCOMPLETE_CONTRADICTIONS,
+    ),
+)
 def test_retirement_spec_rejects_explicit_contradictions(claim):
+    _assert_retirement_contract()
     with pytest.raises(AssertionError, match="contains contradictions"):
         _assert_no_contradictions(_retirement_section_raw() + "\n" + claim)
 

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -111,6 +111,38 @@ CLEANUP_INCOMPLETE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+CLEANUP_INCOMPLETE_PRECOMMIT_ONLY_PATTERN = re.compile(
+    r"""
+    \bcleanup[-_]incomplete\b
+    [^.!?;:]{0,160}?
+    (?:
+        \bonly\s+(?:a\s+)?pre-commit\b
+        |
+        \bpre-commit[- ]only\b
+        |
+        \bonly\s+before\s+(?:the\s+)?primary\s+unlink\b
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+CLEANUP_INCOMPLETE_COMMITTED_UNLINK_PROHIBITION_PATTERN = re.compile(
+    r"""
+    \bcleanup[-_]incomplete\b
+    [^.!?;:]{0,160}?
+    \b(?:never|cannot|can't|must\s+not|may\s+not|does\s+not|do\s+not)\b
+    \s+(?:be\s+)?
+    (?:
+        follow(?:s|ed|ing)?\s+(?:a\s+)?committed\s+primary\s+unlink
+        |
+        (?:occur(?:s|red|ring)?|return(?:s|ed|ing)?)
+        [^.!?;:]{0,80}?
+        \b(?:after|following)\s+(?:a\s+)?committed\s+primary\s+unlink
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
 
 def _retirement_section_raw(spec_path=SPEC_PATH):
     text = spec_path.read_text(encoding="utf-8")
@@ -225,22 +257,13 @@ def _assert_cleanup_incomplete_accounted(section):
             )
     assert matching_units, "SPEC.md must publish cleanup-incomplete prose"
     for unit in matching_units:
-        normalized = unit.lower()
-        precommit_only = "pre-commit" in normalized and bool(
-            re.search(
-                r"\b(?:only|before|without|prevent(?:ed|s|ing)?)\b",
-                normalized,
+        relationship_is_bound = bool(
+            CLEANUP_INCOMPLETE_PRECOMMIT_ONLY_PATTERN.search(unit)
+            or CLEANUP_INCOMPLETE_COMMITTED_UNLINK_PROHIBITION_PATTERN.search(
+                unit
             )
         )
-        committed_unlink_prohibited = (
-            "committed primary unlink" in normalized
-            and re.search(
-                r"\b(?:never|cannot|can't|must not|may not|does not|do not)\b",
-                normalized,
-            )
-            is not None
-        )
-        assert precommit_only or committed_unlink_prohibited, (
+        assert relationship_is_bound, (
             "cleanup-incomplete prose occurrence is not independently "
             f"accounted: {unit!r}"
         )
@@ -334,6 +357,34 @@ def test_retirement_spec_rejects_same_paragraph_cleanup_contradiction():
 
     with pytest.raises(AssertionError, match="contains contradictions"):
         _assert_no_contradictions(mutated)
+
+
+@pytest.mark.parametrize(
+    "contradiction",
+    (
+        (
+            "Cleanup_incomplete may follow a committed primary unlink and "
+            "never requires manual repair."
+        ),
+        (
+            "Cleanup_incomplete may follow a committed primary unlink, "
+            "because a pre-commit check only records diagnostics."
+        ),
+    ),
+)
+def test_retirement_spec_rejects_unrelated_cleanup_qualifiers(
+    contradiction,
+):
+    with pytest.raises(AssertionError, match="contains contradictions"):
+        _assert_no_contradictions(
+            _retirement_section_raw() + "\n" + contradiction
+        )
+
+
+def test_retirement_spec_accepts_only_before_primary_unlink():
+    _assert_cleanup_incomplete_accounted(
+        "Cleanup-incomplete occurs only before the primary unlink."
+    )
 
 
 def test_retirement_conflict_docstring_scopes_availability_to_retiring_primary():

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -95,17 +95,6 @@ ABSENT_MONOLITH_CONTRADICTIONS = (
     "non-retired result with an absent monolith",
 )
 
-CLEANUP_INCOMPLETE_CONTRADICTIONS = (
-    (
-        "Following a successful primary unlink, the operation can still "
-        "return cleanup_incomplete."
-    ),
-    (
-        "The primary index can be unlinked before a cleanup-incomplete "
-        "response is returned."
-    ),
-)
-
 CLEANUP_INCOMPLETE_PATTERN = re.compile(
     r"cleanup[-_]incomplete",
     re.IGNORECASE,
@@ -462,110 +451,50 @@ def test_retirement_commit_outcome_matrix_is_complete_and_consistent():
             assert row["Retiring monolith"] == "loadable"
 
 
-@pytest.mark.parametrize(
-    "claim",
-    (
-        *ABSENT_MONOLITH_CONTRADICTIONS,
-        *CLEANUP_INCOMPLETE_CONTRADICTIONS,
-    ),
-)
-def test_retirement_spec_rejects_explicit_contradictions(claim):
+@pytest.mark.parametrize("claim", ABSENT_MONOLITH_CONTRADICTIONS)
+def test_retirement_spec_rejects_absent_monolith_claims(claim):
+    """Exact-phrase tripwire for the one claim family with no inventory pin.
+
+    Unlike cleanup-incomplete prose, "absent monolith" claims have no
+    canonical sentence set to pin against, so this is a named-phrase check
+    that cannot catch a reworded equivalent. A tripwire, not a proof.
+    """
     _assert_retirement_contract()
     with pytest.raises(AssertionError, match="contains contradictions"):
         _assert_no_contradictions(_retirement_section_raw() + "\n" + claim)
 
 
-def test_retirement_spec_rejects_same_paragraph_cleanup_contradiction():
-    section = _retirement_section_raw()
-    paragraph = next(
-        value
-        for value in re.split(r"\n\s*\n", section)
-        if "cleanup-incomplete reason codes"
-        in " ".join(value.split()).lower()
-        and "never follows a committed primary unlink"
-        in " ".join(value.split()).lower()
-    )
-    contradiction = (
-        "Nevertheless, after a committed primary unlink, the operation may "
-        "return cleanup_incomplete."
-    )
-    mutated = section.replace(paragraph, f"{paragraph} {contradiction}")
-
-    with pytest.raises(AssertionError, match="contains contradictions"):
-        _assert_no_contradictions(mutated)
-
-
 @pytest.mark.parametrize(
-    "contradiction",
+    "sentence",
     (
+        "Cleanup_incomplete may return after a committed primary unlink.",
         (
             "Cleanup_incomplete may follow a committed primary unlink and "
             "never requires manual repair."
         ),
         (
-            "Cleanup_incomplete may follow a committed primary unlink, "
-            "because a pre-commit check only records diagnostics."
-        ),
-    ),
-)
-def test_retirement_spec_rejects_unrelated_cleanup_qualifiers(
-    contradiction,
-):
-    with pytest.raises(AssertionError, match="contains contradictions"):
-        _assert_no_contradictions(
-            _retirement_section_raw() + "\n" + contradiction
-        )
-
-
-@pytest.mark.parametrize(
-    "contradiction",
-    (
-        (
             "Cleanup_incomplete never follows a committed primary unlink but "
             "cleanup_incomplete may return after a committed primary unlink."
         ),
         (
-            "Cleanup_incomplete may follow a committed primary unlink while "
-            "monitoring runs only before the primary unlink."
+            "Only before the primary unlink may cleanup-incomplete occur "
+            "after a committed primary unlink."
         ),
     ),
 )
-def test_retirement_spec_rejects_cross_occurrence_qualifiers(
-    contradiction,
-):
+def test_any_added_cleanup_incomplete_sentence_fails_the_inventory(sentence):
+    """The guard pins the inventory; it does not judge meaning.
+
+    Cleanup-incomplete prose is protected by pinning the COMPLETE set of
+    sentences that mention it, so ANY addition fails — contradictory,
+    redundant, or merely new. That is what makes the guard sound: scanning for
+    specific contradictory phrasings could never be complete, because a
+    contradiction can always be reworded. These cases sample the property;
+    they are not the list of phrasings it covers.
+    """
     with pytest.raises(AssertionError, match="contains contradictions"):
         _assert_no_contradictions(
-            _retirement_section_raw() + "\n" + contradiction
-        )
-
-
-@pytest.mark.parametrize(
-    "contradiction",
-    (
-        (
-            "Cleanup_incomplete never follows a committed primary unlink and "
-            "may return after a committed primary unlink."
-        ),
-        (
-            "Cleanup_incomplete occurs only before the primary unlink and may "
-            "return after a committed primary unlink."
-        ),
-        (
-            "Only before the primary unlink may cleanup-incomplete occur after "
-            "a committed primary unlink."
-        ),
-        (
-            "After a committed primary unlink, cleanup_incomplete cannot occur "
-            "but may return after a committed primary unlink."
-        ),
-    ),
-)
-def test_retirement_spec_rejects_noncanonical_cleanup_claims(
-    contradiction,
-):
-    with pytest.raises(AssertionError, match="contains contradictions"):
-        _assert_no_contradictions(
-            _retirement_section_raw() + "\n" + contradiction
+            _retirement_section_raw() + "\n" + sentence
         )
 
 
@@ -575,129 +504,98 @@ def _write_mutated_spec(tmp_path, text):
     return spec_path
 
 
-def test_retirement_spec_rejects_cleanup_prose_after_section_boundary(
-    tmp_path,
-):
-    text = SPEC_PATH.read_text(encoding="utf-8")
-    contradiction = (
-        "Cleanup_incomplete may return after a committed primary unlink."
+CONTRADICTION = (
+    "Cleanup_incomplete may return after a committed primary unlink."
+)
+GIT_TABLE_END = "\n\n**`reconciliation.reason_code`**"
+
+
+def _authoritative_row(text):
+    return next(
+        line
+        for line in text.splitlines()
+        if line.startswith("| `supersession_cleanup_incomplete` |")
     )
-    mutated = text.replace(
-        SECTION_END,
-        f"{SECTION_END}\n\n{contradiction}",
-        1,
-    )
-
-    with pytest.raises(AssertionError):
-        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
 
 
-def test_retirement_spec_rejects_escaped_cleanup_prose(tmp_path):
-    text = SPEC_PATH.read_text(encoding="utf-8")
-    contradiction = (
+def _after_section_boundary(text):
+    """Drift parked just outside the section, still inside the document."""
+    return text.replace(SECTION_END, f"{SECTION_END}\n\n{CONTRADICTION}", 1)
+
+
+def _markdown_escaped(text):
+    """An escaped underscore renders identically to a reader."""
+    escaped = (
         "Cleanup\\_incomplete may return after a committed primary unlink."
     )
-    mutated = text.replace(
+    return text.replace(SECTION_START, f"{SECTION_START}\n\n{escaped}", 1)
+
+
+def _indented_fence(text):
+    """Four spaces open an indented code block, not a fence — still visible."""
+    return text.replace(
         SECTION_START,
-        f"{SECTION_START}\n\n{contradiction}",
+        f"{SECTION_START}\n\n    ```\n{CONTRADICTION}\n    ```",
         1,
     )
 
-    with pytest.raises(AssertionError):
-        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
 
-
-def test_retirement_spec_rejects_reason_code_moved_to_wrong_table(tmp_path):
-    text = SPEC_PATH.read_text(encoding="utf-8")
-    row = next(
-        line
-        for line in text.splitlines()
-        if line.startswith("| `supersession_cleanup_incomplete` |")
-    )
-    mutated = text.replace(f"{row}\n", "", 1)
-    git_table_end = (
-        "\n\n**`reconciliation.reason_code`**"
-    )
-    mutated = mutated.replace(
-        git_table_end,
-        f"\n{row}{git_table_end}",
-        1,
+def _reason_code_in_wrong_table(text):
+    """An authoritative row relocated under a different table label."""
+    row = _authoritative_row(text)
+    return text.replace(f"{row}\n", "", 1).replace(
+        GIT_TABLE_END, f"\n{row}{GIT_TABLE_END}", 1
     )
 
-    with pytest.raises(AssertionError):
-        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
 
-
-def test_retirement_spec_rejects_contradictory_authoritative_row(tmp_path):
-    text = SPEC_PATH.read_text(encoding="utf-8")
-    row = next(
-        line
-        for line in text.splitlines()
-        if line.startswith("| `supersession_cleanup_incomplete` |")
-    )
-    contradiction = (
+def _contradiction_appended_to_row(text):
+    """Drift smuggled onto the end of an otherwise correct row."""
+    row = _authoritative_row(text)
+    appended = (
         " Nevertheless, after a committed primary unlink, the operation may "
         "return cleanup_incomplete."
     )
-    mutated_row = row[:-1].rstrip() + contradiction + " |"
-    mutated = text.replace(row, mutated_row, 1)
-
-    with pytest.raises(AssertionError):
-        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
+    return text.replace(row, row[:-1].rstrip() + appended + " |", 1)
 
 
-def test_retirement_spec_rejects_escaped_shadow_reason_code(tmp_path):
-    text = SPEC_PATH.read_text(encoding="utf-8")
-    shadow_row = (
-        "| `shadow_cleanup\\_incomplete` | A visible shadow outcome. |"
-    )
-    git_table_end = (
-        "\n\n**`reconciliation.reason_code`**"
-    )
-    mutated = text.replace(
-        git_table_end,
-        f"\n{shadow_row}{git_table_end}",
-        1,
-    )
-
-    with pytest.raises(AssertionError):
-        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
+def _escaped_shadow_reason_code(text):
+    """A fourth reason code that renders like one of the real three."""
+    shadow = "| `shadow_cleanup\\_incomplete` | A visible shadow outcome. |"
+    return text.replace(GIT_TABLE_END, f"\n{shadow}{GIT_TABLE_END}", 1)
 
 
-def test_retirement_spec_rejects_extra_cell_hiding_authoritative_outcome(
-    tmp_path,
-):
-    text = SPEC_PATH.read_text(encoding="utf-8")
-    row = next(
-        line
-        for line in text.splitlines()
-        if line.startswith("| `supersession_cleanup_incomplete` |")
-    )
+def _extra_cell_hiding_the_outcome(text):
+    """An inserted column, so the last cell is no longer the outcome."""
+    row = _authoritative_row(text)
     cells = [cell.strip() for cell in row.strip("|").split("|")]
-    contradiction = (
-        "Cleanup_incomplete may return after a committed primary unlink."
+    return text.replace(
+        row, f"| {cells[0]} | {CONTRADICTION} | {cells[1]} |", 1
     )
-    mutated_row = (
-        f"| {cells[0]} | {contradiction} | {cells[1]} |"
-    )
-    mutated = text.replace(row, mutated_row, 1)
-
-    with pytest.raises(AssertionError):
-        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
 
 
-def test_retirement_spec_rejects_cleanup_prose_after_four_space_fence_marker(
-    tmp_path,
-):
-    text = SPEC_PATH.read_text(encoding="utf-8")
-    contradiction = (
-        "Cleanup_incomplete may return after a committed primary unlink."
-    )
-    mutated = text.replace(
-        SECTION_START,
-        f"{SECTION_START}\n\n    ```\n{contradiction}\n    ```",
-        1,
-    )
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        _after_section_boundary,
+        _markdown_escaped,
+        _indented_fence,
+        _reason_code_in_wrong_table,
+        _contradiction_appended_to_row,
+        _escaped_shadow_reason_code,
+        _extra_cell_hiding_the_outcome,
+    ),
+    ids=lambda mutate: mutate.__name__.lstrip("_"),
+)
+def test_retirement_spec_guard_reads_what_a_reader_sees(tmp_path, mutate):
+    """Each case defeats a different part of the guard's reader model.
+
+    The guard has to decide what a reader actually SEES: which lines sit
+    inside a real fence, how markdown escapes render, and which column carries
+    the authoritative outcome. A mutation slipping past any of those would let
+    SPEC.md drift while this suite stayed green, so each model is pinned once
+    here rather than as its own near-identical test.
+    """
+    mutated = mutate(SPEC_PATH.read_text(encoding="utf-8"))
 
     with pytest.raises(AssertionError):
         _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -84,7 +84,7 @@ EXPECTED_OUTCOME_MATRIX = {
         "Retiring monolith": "absent",
         "Cleanup fields": "present",
         "Durable recovery": (
-            "The four fields report durable state; a fresh pending read "
+            "The cleanup fields report durable state; a fresh pending read "
             "self-heals or returns the record."
         ),
     },
@@ -426,6 +426,34 @@ def test_cleanup_incomplete_inventories_are_canonical():
         ),
     }
     _assert_cleanup_incomplete_table_inventory()
+
+
+NUMBER_WORDS = {
+    "one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+}
+COUNTED_FIELDS_PATTERN = re.compile(
+    r"\b(one|two|three|four|five|six)\b\s+(?:[^\s]*\s+)?fields",
+    re.IGNORECASE,
+)
+
+
+def test_spec_never_hardcodes_a_stale_cleanup_field_count():
+    """Prose that counts the cleanup fields must agree with the schema.
+
+    Removing the write-only completion marker left SPEC.md saying "four" in
+    two places while three fields remained, and the guard did not notice
+    because it pinned the sentence verbatim -- a pinned string is only as
+    current as the last person who remembered to update both copies. This
+    derives the count from the runtime schema instead.
+    """
+    section = _retirement_section_raw()
+    expected = len(storage_module.RETIREMENT_CLEANUP_OUTCOME_SCHEMA)
+
+    for match in COUNTED_FIELDS_PATTERN.finditer(section):
+        assert NUMBER_WORDS[match.group(1).lower()] == expected, (
+            f"SPEC.md says {match.group(0)!r} but the runtime schema "
+            f"publishes {expected} cleanup fields"
+        )
 
 
 def test_cleanup_disclosure_schema_matches_storage_emitter():

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -107,7 +107,7 @@ CLEANUP_INCOMPLETE_CONTRADICTIONS = (
 )
 
 CLEANUP_INCOMPLETE_PATTERN = re.compile(
-    r"\bcleanup[-_]incomplete\b",
+    r"cleanup[-_]incomplete",
     re.IGNORECASE,
 )
 
@@ -124,6 +124,41 @@ CLEANUP_INCOMPLETE_REASON_CODE_INVENTORY = (
     "graduation_cleanup_incomplete",
     "legacy_reconcile_cleanup_incomplete",
 )
+
+CANONICAL_CLEANUP_INCOMPLETE_TABLES = {
+    "reconciliation.reason_code": (
+        (
+            "supersession_cleanup_incomplete",
+            (
+                "Supersession was proven, but a pre-commit publication or "
+                "cleanup failure prevented the primary unlink; the provisional "
+                "remains discoverable and retry is idempotent."
+            ),
+        ),
+        (
+            "graduation_cleanup_incomplete",
+            (
+                "Exact-duplicate graduation was proven, but a pre-commit "
+                "publication or cleanup failure prevented the primary unlink; "
+                "nothing was reconciled, the provisional remains discoverable, "
+                "and retry is idempotent."
+            ),
+        ),
+    ),
+    "legacy_reconciliation.reason_code": (
+        (
+            "legacy_reconcile_cleanup_incomplete",
+            (
+                "Retirement was proven, but a pre-commit publication or cleanup "
+                "failure prevented the primary unlink; the legacy index remains "
+                "discoverable and retry is idempotent."
+            ),
+        ),
+    ),
+}
+
+MARKDOWN_ESCAPE_PATTERN = re.compile(r"\\([\\`*_{}\[\]()#+.!|<>-])")
+FENCE_PATTERN = re.compile(r"^\s*(`{3,}|~{3,})")
 
 
 def _retirement_section_raw(spec_path=SPEC_PATH):
@@ -178,8 +213,8 @@ def _published_cleanup_schema():
     }
 
 
-def _assert_no_contradictions(section):
-    normalized = " ".join(section.split()).lower()
+def _assert_no_contradictions(document_text):
+    normalized = " ".join(document_text.split()).lower()
     contradictions = [
         claim
         for claim in ABSENT_MONOLITH_CONTRADICTIONS
@@ -189,64 +224,167 @@ def _assert_no_contradictions(section):
         "SPEC.md retirement coordination contains contradictions: "
         + ", ".join(contradictions)
     )
-    actual_inventory = _cleanup_incomplete_prose_inventory(section)
+    actual_inventory = _cleanup_incomplete_prose_inventory(document_text)
     assert actual_inventory == CLEANUP_INCOMPLETE_PROSE_INVENTORY, (
-        "SPEC.md retirement coordination contains contradictions: "
+        "SPEC.md contains contradictions: "
         "cleanup-incomplete prose inventory differs from the canonical "
         f"contract: {actual_inventory!r}"
     )
 
 
+def _normalize_markdown_surface(text):
+    without_escapes = MARKDOWN_ESCAPE_PATTERN.sub(r"\1", text)
+    return " ".join(without_escapes.replace("`", "").split()).lower()
+
+
 def _normalize_cleanup_incomplete_sentence(sentence):
-    without_backticks = sentence.replace("`", "")
+    without_rendering = _normalize_markdown_surface(sentence)
     canonical_spelling = CLEANUP_INCOMPLETE_PATTERN.sub(
         "cleanup-incomplete",
-        without_backticks,
+        without_rendering,
     )
-    return " ".join(canonical_spelling.split()).lower()
+    return canonical_spelling
 
 
-def _cleanup_incomplete_prose_inventory(section):
+def _visible_markdown_lines(text):
+    in_fence = False
+    fence_character = None
+    fence_length = 0
+    for line in text.splitlines():
+        marker_match = FENCE_PATTERN.match(line)
+        if marker_match:
+            marker = marker_match.group(1)
+            if not in_fence:
+                in_fence = True
+                fence_character = marker[0]
+                fence_length = len(marker)
+            elif marker[0] == fence_character and len(marker) >= fence_length:
+                in_fence = False
+                fence_character = None
+                fence_length = 0
+            continue
+        if not in_fence:
+            yield line
+
+
+def _cleanup_incomplete_prose_inventory(document_text):
     prose = "\n".join(
-        line for line in section.splitlines() if not line.startswith("|")
+        line
+        for line in _visible_markdown_lines(document_text)
+        if not line.lstrip().startswith("|")
     )
     sentences = re.split(r"(?<=[.!?])\s+", " ".join(prose.split()))
     return tuple(
-        _normalize_cleanup_incomplete_sentence(sentence)
+        normalized
         for sentence in sentences
-        if CLEANUP_INCOMPLETE_PATTERN.search(sentence)
+        if CLEANUP_INCOMPLETE_PATTERN.search(
+            normalized := _normalize_cleanup_incomplete_sentence(sentence)
+        )
     )
+
+
+def _normalize_reason_code(cell):
+    normalized = _normalize_markdown_surface(cell)
+    return CLEANUP_INCOMPLETE_PATTERN.sub(
+        "cleanup_incomplete",
+        normalized,
+    )
+
+
+def _markdown_table_rows(text):
+    rows = []
+    for line in _visible_markdown_lines(text):
+        if not line.lstrip().startswith("|"):
+            continue
+        cells = tuple(line.strip().strip("|").split("|"))
+        rows.append(cells)
+    return tuple(rows)
 
 
 def _cleanup_incomplete_reason_code_rows(spec_path=SPEC_PATH):
     rows = []
-    for line in spec_path.read_text(encoding="utf-8").splitlines():
-        if not line.startswith("|"):
+    text = spec_path.read_text(encoding="utf-8")
+    for cells in _markdown_table_rows(text):
+        normalized_cells = tuple(
+            _normalize_cleanup_incomplete_sentence(cell) for cell in cells
+        )
+        if not any(
+            CLEANUP_INCOMPLETE_PATTERN.search(cell)
+            for cell in normalized_cells
+        ):
             continue
-        cells = [
-            cell.strip().replace("`", "").lower()
-            for cell in line.strip("|").split("|")
-        ]
-        if cells[0].endswith("_cleanup_incomplete"):
-            rows.append((cells[0], cells[-1]))
+        rows.append(
+            (
+                _normalize_reason_code(cells[0]),
+                _normalize_cleanup_incomplete_sentence(cells[-1]),
+            )
+        )
+    return tuple(rows)
+
+
+def _cleanup_incomplete_rows_for_table(text, label):
+    lines = tuple(_visible_markdown_lines(text))
+    label_marker = f"**`{label}`**"
+    label_indexes = [
+        index
+        for index, line in enumerate(lines)
+        if line.startswith(label_marker)
+    ]
+    assert len(label_indexes) == 1, (
+        f"SPEC.md must contain exactly one {label_marker} table label"
+    )
+    start = next(
+        index
+        for index in range(label_indexes[0] + 1, len(lines))
+        if lines[index].lstrip().startswith("|")
+    )
+    table_lines = []
+    for line in lines[start:]:
+        if not line.lstrip().startswith("|"):
+            break
+        table_lines.append(line)
+    rows = []
+    for cells in _markdown_table_rows("\n".join(table_lines))[2:]:
+        reason_code = _normalize_reason_code(cells[0])
+        if reason_code.endswith("_cleanup_incomplete"):
+            rows.append(
+                (
+                    reason_code,
+                    _normalize_cleanup_incomplete_sentence(cells[-1]),
+                )
+            )
     return tuple(rows)
 
 
 def _assert_cleanup_incomplete_table_inventory(spec_path=SPEC_PATH):
+    text = spec_path.read_text(encoding="utf-8")
+    normalized_expected = {
+        label: tuple(
+            (
+                reason_code,
+                _normalize_cleanup_incomplete_sentence(outcome),
+            )
+            for reason_code, outcome in rows
+        )
+        for label, rows in CANONICAL_CLEANUP_INCOMPLETE_TABLES.items()
+    }
+    actual_by_table = {
+        label: _cleanup_incomplete_rows_for_table(text, label)
+        for label in CANONICAL_CLEANUP_INCOMPLETE_TABLES
+    }
+    assert actual_by_table == normalized_expected
+
     rows = _cleanup_incomplete_reason_code_rows(spec_path)
-    assert tuple(reason_code for reason_code, _ in rows) == (
-        CLEANUP_INCOMPLETE_REASON_CODE_INVENTORY
+    expected_rows = tuple(
+        row
+        for table_rows in normalized_expected.values()
+        for row in table_rows
     )
-    for reason_code, meaning in rows:
-        assert "pre-commit" in meaning, (
-            f"{reason_code} table row is not pre-commit"
-        )
-        assert "prevented the primary unlink" in meaning, (
-            f"{reason_code} table row does not prevent unlink"
-        )
+    assert rows == expected_rows
 
 
 def _assert_retirement_contract(spec_path=SPEC_PATH):
+    text = spec_path.read_text(encoding="utf-8")
     raw_section = _retirement_section_raw(spec_path)
     section = " ".join(raw_section.split()).lower()
     missing = [
@@ -258,7 +396,7 @@ def _assert_retirement_contract(spec_path=SPEC_PATH):
         "SPEC.md retirement coordination is missing contracts: "
         + ", ".join(missing)
     )
-    _assert_no_contradictions(raw_section)
+    _assert_no_contradictions(text)
     _assert_cleanup_incomplete_table_inventory(spec_path)
 
 
@@ -268,12 +406,26 @@ def test_retirement_coordination_spec_matches_commit_contract():
 
 def test_cleanup_incomplete_inventories_are_canonical():
     assert _cleanup_incomplete_prose_inventory(
-        _retirement_section_raw()
+        SPEC_PATH.read_text(encoding="utf-8")
     ) == CLEANUP_INCOMPLETE_PROSE_INVENTORY
     rows = _cleanup_incomplete_reason_code_rows()
     assert tuple(reason_code for reason_code, _ in rows) == (
         CLEANUP_INCOMPLETE_REASON_CODE_INVENTORY
     )
+    text = SPEC_PATH.read_text(encoding="utf-8")
+    assert {
+        label: tuple(reason_code for reason_code, _ in rows)
+        for label in CANONICAL_CLEANUP_INCOMPLETE_TABLES
+        for rows in (_cleanup_incomplete_rows_for_table(text, label),)
+    } == {
+        "reconciliation.reason_code": (
+            "supersession_cleanup_incomplete",
+            "graduation_cleanup_incomplete",
+        ),
+        "legacy_reconciliation.reason_code": (
+            "legacy_reconcile_cleanup_incomplete",
+        ),
+    }
     _assert_cleanup_incomplete_table_inventory()
 
 
@@ -405,6 +557,101 @@ def test_retirement_spec_rejects_noncanonical_cleanup_claims(
         _assert_no_contradictions(
             _retirement_section_raw() + "\n" + contradiction
         )
+
+
+def _write_mutated_spec(tmp_path, text):
+    spec_path = tmp_path / "SPEC.md"
+    spec_path.write_text(text, encoding="utf-8")
+    return spec_path
+
+
+def test_retirement_spec_rejects_cleanup_prose_after_section_boundary(
+    tmp_path,
+):
+    text = SPEC_PATH.read_text(encoding="utf-8")
+    contradiction = (
+        "Cleanup_incomplete may return after a committed primary unlink."
+    )
+    mutated = text.replace(
+        SECTION_END,
+        f"{SECTION_END}\n\n{contradiction}",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
+
+
+def test_retirement_spec_rejects_escaped_cleanup_prose(tmp_path):
+    text = SPEC_PATH.read_text(encoding="utf-8")
+    contradiction = (
+        "Cleanup\\_incomplete may return after a committed primary unlink."
+    )
+    mutated = text.replace(
+        SECTION_START,
+        f"{SECTION_START}\n\n{contradiction}",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
+
+
+def test_retirement_spec_rejects_reason_code_moved_to_wrong_table(tmp_path):
+    text = SPEC_PATH.read_text(encoding="utf-8")
+    row = next(
+        line
+        for line in text.splitlines()
+        if line.startswith("| `supersession_cleanup_incomplete` |")
+    )
+    mutated = text.replace(f"{row}\n", "", 1)
+    git_table_end = (
+        "\n\n**`reconciliation.reason_code`**"
+    )
+    mutated = mutated.replace(
+        git_table_end,
+        f"\n{row}{git_table_end}",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
+
+
+def test_retirement_spec_rejects_contradictory_authoritative_row(tmp_path):
+    text = SPEC_PATH.read_text(encoding="utf-8")
+    row = next(
+        line
+        for line in text.splitlines()
+        if line.startswith("| `supersession_cleanup_incomplete` |")
+    )
+    contradiction = (
+        " Nevertheless, after a committed primary unlink, the operation may "
+        "return cleanup_incomplete."
+    )
+    mutated_row = row[:-1].rstrip() + contradiction + " |"
+    mutated = text.replace(row, mutated_row, 1)
+
+    with pytest.raises(AssertionError):
+        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
+
+
+def test_retirement_spec_rejects_escaped_shadow_reason_code(tmp_path):
+    text = SPEC_PATH.read_text(encoding="utf-8")
+    shadow_row = (
+        "| `shadow_cleanup\\_incomplete` | A visible shadow outcome. |"
+    )
+    git_table_end = (
+        "\n\n**`reconciliation.reason_code`**"
+    )
+    mutated = text.replace(
+        git_table_end,
+        f"\n{shadow_row}{git_table_end}",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
 
 
 def test_retirement_conflict_docstring_scopes_availability_to_retiring_primary():

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -1,0 +1,63 @@
+"""Issue #95 retirement coordination specification contract."""
+
+from pathlib import Path
+
+
+SPEC_PATH = Path(__file__).parents[1] / "SPEC.md"
+SECTION_START = "**Retirement coordination**"
+SECTION_END = '`legacy_reconcile="report"`'
+
+REQUIRED_CONTRACTS = {
+    "exact publication authority": (
+        "a readable current retirement record with the exact current "
+        "publication identity"
+    ),
+    "post-retained-gate proof": (
+        "after the retained-handle gate is acquired and immediately before "
+        "the primary `<name>.json` commit"
+    ),
+    "conditional cleanup": (
+        "stale or older cleanup cannot remove a newer publication"
+    ),
+    "truthful completion recovery": (
+        "failure after the primary unlink remains truthfully recoverable"
+    ),
+    "fresh-read self-healing": (
+        "a fresh pending-state read self-heals the completed deletion"
+    ),
+    "commit-scoped availability": (
+        "at the protected A-to-B commit, B is loadable"
+    ),
+    "sequential retirement": (
+        "a later separately authorized B-to-C retirement may legitimately "
+        "remove B"
+    ),
+    "wait policy": (
+        "public deletion uses zero-wait coordination, while internal "
+        "retirement uses its bounded wait"
+    ),
+}
+
+
+def _retirement_section(spec_path=SPEC_PATH):
+    text = spec_path.read_text(encoding="utf-8")
+    start = text.index(SECTION_START)
+    end = text.index(SECTION_END, start)
+    return " ".join(text[start:end].split()).lower()
+
+
+def _assert_retirement_contract(spec_path=SPEC_PATH):
+    section = _retirement_section(spec_path)
+    missing = [
+        name
+        for name, statement in REQUIRED_CONTRACTS.items()
+        if statement.lower() not in section
+    ]
+    assert not missing, (
+        "SPEC.md retirement coordination is missing contracts: "
+        + ", ".join(missing)
+    )
+
+
+def test_retirement_coordination_spec_matches_commit_contract():
+    _assert_retirement_contract()

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -208,19 +208,42 @@ def _assert_cleanup_incomplete_accounted(section):
     prose = "\n".join(
         line for line in section.splitlines() if not line.startswith("|")
     )
-    paragraphs = [
-        paragraph.strip()
-        for paragraph in re.split(r"\n\s*\n", prose)
-        if CLEANUP_INCOMPLETE_PATTERN.search(paragraph)
-    ]
-    for paragraph in paragraphs:
-        normalized = " ".join(paragraph.split()).lower()
-        assert "pre-commit" in normalized, (
-            "cleanup-incomplete prose is not explicitly pre-commit"
+    matching_units = []
+    for paragraph in re.split(r"\n\s*\n", prose):
+        normalized_paragraph = " ".join(paragraph.split())
+        sentences = re.split(r"(?<=[.!?])\s+", normalized_paragraph)
+        for sentence in sentences:
+            clauses = re.split(
+                r";\s+|:\s+|,\s+(?=(?:and|but|yet|or)\b)",
+                sentence,
+                flags=re.IGNORECASE,
+            )
+            matching_units.extend(
+                clause.strip()
+                for clause in clauses
+                if CLEANUP_INCOMPLETE_PATTERN.search(clause)
+            )
+    assert matching_units, "SPEC.md must publish cleanup-incomplete prose"
+    for unit in matching_units:
+        normalized = unit.lower()
+        precommit_only = "pre-commit" in normalized and bool(
+            re.search(
+                r"\b(?:only|before|without|prevent(?:ed|s|ing)?)\b",
+                normalized,
+            )
         )
-        assert (
-            "never follows a committed primary unlink" in normalized
-        ), "cleanup-incomplete prose permits a committed unlink"
+        committed_unlink_prohibited = (
+            "committed primary unlink" in normalized
+            and re.search(
+                r"\b(?:never|cannot|can't|must not|may not|does not|do not)\b",
+                normalized,
+            )
+            is not None
+        )
+        assert precommit_only or committed_unlink_prohibited, (
+            "cleanup-incomplete prose occurrence is not independently "
+            f"accounted: {unit!r}"
+        )
 
 
 def _assert_retirement_contract(spec_path=SPEC_PATH):
@@ -291,6 +314,26 @@ def test_retirement_spec_rejects_explicit_contradictions(claim):
     _assert_retirement_contract()
     with pytest.raises(AssertionError, match="contains contradictions"):
         _assert_no_contradictions(_retirement_section_raw() + "\n" + claim)
+
+
+def test_retirement_spec_rejects_same_paragraph_cleanup_contradiction():
+    section = _retirement_section_raw()
+    paragraph = next(
+        value
+        for value in re.split(r"\n\s*\n", section)
+        if "cleanup-incomplete reason codes"
+        in " ".join(value.split()).lower()
+        and "never follows a committed primary unlink"
+        in " ".join(value.split()).lower()
+    )
+    contradiction = (
+        "Nevertheless, after a committed primary unlink, the operation may "
+        "return cleanup_incomplete."
+    )
+    mutated = section.replace(paragraph, f"{paragraph} {contradiction}")
+
+    with pytest.raises(AssertionError, match="contains contradictions"):
+        _assert_no_contradictions(mutated)
 
 
 def test_retirement_conflict_docstring_scopes_availability_to_retiring_primary():

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -514,7 +514,7 @@ def test_any_added_cleanup_incomplete_sentence_fails_the_inventory(sentence):
     """The guard pins the inventory; it does not judge meaning.
 
     Cleanup-incomplete prose is protected by pinning the COMPLETE set of
-    sentences that mention it, so ANY addition fails — contradictory,
+    sentences that mention it, so ANY addition fails, whether contradictory,
     redundant, or merely new. That is what makes the guard sound: scanning for
     specific contradictory phrasings could never be complete, because a
     contradiction can always be reworded. These cases sample the property;
@@ -560,7 +560,7 @@ def _markdown_escaped(text):
 
 
 def _indented_fence(text):
-    """Four spaces open an indented code block, not a fence — still visible."""
+    """Four spaces open an indented code block, not a fence, so it stays visible."""
     return text.replace(
         SECTION_START,
         f"{SECTION_START}\n\n    ```\n{CONTRADICTION}\n    ```",

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -111,92 +111,18 @@ CLEANUP_INCOMPLETE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-CLEANUP_INCOMPLETE_PRECOMMIT_ONLY_PATTERN = re.compile(
-    r"""
-    \bcleanup[-_]incomplete\b
-    (?:\s+(?:outcome|reason\s+codes?))?
-    \s+(?:occur(?:s|red|ring)?|return(?:s|ed|ing)?|describe(?:s|d)?)
-    [^.!?;:]{0,40}?
-    (?:
-        \bonly\s+(?:a\s+)?pre-commit\b
-        |
-        \bpre-commit[- ]only\b
-        |
-        \bonly\s+before\s+(?:the\s+)?primary\s+unlink\b
-    )
-    """,
-    re.IGNORECASE | re.VERBOSE,
+CLEANUP_INCOMPLETE_PROSE_INVENTORY = (
+    (
+        "cleanup-incomplete reason codes describe only a pre-commit failure, "
+        "and a cleanup-incomplete outcome never follows a committed primary "
+        "unlink."
+    ),
 )
 
-CLEANUP_INCOMPLETE_COMMITTED_UNLINK_PROHIBITION_PATTERN = re.compile(
-    r"""
-    \bcleanup[-_]incomplete\b
-    (?:\s+(?:outcome|response|reason\s+codes?))?
-    \s+
-    \b(?:never|cannot|can't|must\s+not|may\s+not|does\s+not|do\s+not)\b
-    \s+(?:be\s+)?
-    (?:
-        follow(?:s|ed|ing)?\s+(?:a\s+)?committed\s+primary\s+unlink
-        |
-        (?:occur(?:s|red|ring)?|return(?:s|ed|ing)?)
-        [^.!?;:]{0,80}?
-        \b(?:after|following)\s+(?:a\s+)?committed\s+primary\s+unlink
-    )
-    """,
-    re.IGNORECASE | re.VERBOSE,
-)
-
-CLEANUP_INCOMPLETE_LEADING_PRECOMMIT_ONLY_PATTERN = re.compile(
-    r"""
-    (?:
-        \bonly\s+(?:a\s+)?pre-commit\b
-        |
-        \bpre-commit[- ]only\b
-        |
-        \bonly\s+before\s+(?:the\s+)?primary\s+unlink\b
-    )
-    \s*,?\s+
-    (?:(?:may|can|does)\s+)?
-    \bcleanup[-_]incomplete\b
-    (?:\s+(?:outcome|response))?
-    \s+(?:(?:may|can|does)\s+)?
-    (?:occur(?:s|red|ring)?|return(?:s|ed|ing)?)
-    """,
-    re.IGNORECASE | re.VERBOSE,
-)
-
-CLEANUP_INCOMPLETE_LEADING_COMMITTED_UNLINK_PROHIBITION_PATTERN = re.compile(
-    r"""
-    \b(?:after|following)\s+(?:a\s+)?committed\s+primary\s+unlink\b
-    \s*,?\s+
-    \bcleanup[-_]incomplete\b
-    (?:\s+(?:outcome|response))?
-    \s+
-    \b(?:never|cannot|can't|must\s+not|may\s+not|does\s+not|do\s+not)\b
-    \s+(?:be\s+)?
-    (?:follow(?:s|ed|ing)?|occur(?:s|red|ring)?|return(?:s|ed|ing)?)
-    """,
-    re.IGNORECASE | re.VERBOSE,
-)
-
-CLEANUP_INCOMPLETE_RELATIONSHIP_PATTERNS = (
-    CLEANUP_INCOMPLETE_PRECOMMIT_ONLY_PATTERN,
-    CLEANUP_INCOMPLETE_COMMITTED_UNLINK_PROHIBITION_PATTERN,
-    CLEANUP_INCOMPLETE_LEADING_PRECOMMIT_ONLY_PATTERN,
-    CLEANUP_INCOMPLETE_LEADING_COMMITTED_UNLINK_PROHIBITION_PATTERN,
-)
-
-CLEANUP_INCOMPLETE_RELATIONSHIP_BOUNDARY_PATTERN = re.compile(
-    r"""
-    ;\s+
-    |
-    :\s+
-    |
-    ,\s+(?=(?:and|yet|or)\b)
-    |
-    (?:,\s*|\s+)(?:but|while|because)\s+
-    """,
-    re.IGNORECASE | re.VERBOSE,
+CLEANUP_INCOMPLETE_REASON_CODE_INVENTORY = (
+    "supersession_cleanup_incomplete",
+    "graduation_cleanup_incomplete",
+    "legacy_reconcile_cleanup_incomplete",
 )
 
 
@@ -263,72 +189,66 @@ def _assert_no_contradictions(section):
         "SPEC.md retirement coordination contains contradictions: "
         + ", ".join(contradictions)
     )
-    try:
-        _assert_cleanup_incomplete_accounted(section)
-    except AssertionError as exc:
-        raise AssertionError(
-            "SPEC.md retirement coordination contains contradictions: "
-            f"{exc}"
-        ) from exc
+    actual_inventory = _cleanup_incomplete_prose_inventory(section)
+    assert actual_inventory == CLEANUP_INCOMPLETE_PROSE_INVENTORY, (
+        "SPEC.md retirement coordination contains contradictions: "
+        "cleanup-incomplete prose inventory differs from the canonical "
+        f"contract: {actual_inventory!r}"
+    )
 
 
-def _assert_cleanup_incomplete_accounted(section):
-    matching_lines = [
-        line
-        for line in section.splitlines()
-        if CLEANUP_INCOMPLETE_PATTERN.search(line)
-    ]
-    assert matching_lines, "SPEC.md must publish cleanup-incomplete semantics"
-    for row in (line for line in matching_lines if line.startswith("|")):
-        cells = [
-            cell.strip().replace("`", "").lower()
-            for cell in row.strip("|").split("|")
-        ]
-        assert cells[0].endswith("cleanup_incomplete"), (
-            "cleanup-incomplete table occurrence is not a reason code"
-        )
-        assert "pre-commit" in cells[-1], (
-            "cleanup-incomplete table row is not pre-commit"
-        )
-        assert "prevented the primary unlink" in cells[-1], (
-            "cleanup-incomplete table row does not prevent unlink"
-        )
+def _normalize_cleanup_incomplete_sentence(sentence):
+    without_backticks = sentence.replace("`", "")
+    canonical_spelling = CLEANUP_INCOMPLETE_PATTERN.sub(
+        "cleanup-incomplete",
+        without_backticks,
+    )
+    return " ".join(canonical_spelling.split()).lower()
+
+
+def _cleanup_incomplete_prose_inventory(section):
     prose = "\n".join(
         line for line in section.splitlines() if not line.startswith("|")
     )
-    matching_units = []
-    for paragraph in re.split(r"\n\s*\n", prose):
-        normalized_paragraph = " ".join(paragraph.split())
-        sentences = re.split(r"(?<=[.!?])\s+", normalized_paragraph)
-        for sentence in sentences:
-            clauses = CLEANUP_INCOMPLETE_RELATIONSHIP_BOUNDARY_PATTERN.split(
-                sentence
-            )
-            matching_units.extend(
-                clause.strip()
-                for clause in clauses
-                if CLEANUP_INCOMPLETE_PATTERN.search(clause)
-            )
-    assert matching_units, "SPEC.md must publish cleanup-incomplete prose"
-    for unit in matching_units:
-        allowed_spans = [
-            match.span()
-            for pattern in CLEANUP_INCOMPLETE_RELATIONSHIP_PATTERNS
-            for match in pattern.finditer(unit)
+    sentences = re.split(r"(?<=[.!?])\s+", " ".join(prose.split()))
+    return tuple(
+        _normalize_cleanup_incomplete_sentence(sentence)
+        for sentence in sentences
+        if CLEANUP_INCOMPLETE_PATTERN.search(sentence)
+    )
+
+
+def _cleanup_incomplete_reason_code_rows(spec_path=SPEC_PATH):
+    rows = []
+    for line in spec_path.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [
+            cell.strip().replace("`", "").lower()
+            for cell in line.strip("|").split("|")
         ]
-        for occurrence in CLEANUP_INCOMPLETE_PATTERN.finditer(unit):
-            occurrence_is_bound = any(
-                start <= occurrence.start() and occurrence.end() <= end
-                for start, end in allowed_spans
-            )
-            assert occurrence_is_bound, (
-                "cleanup-incomplete prose occurrence is not independently "
-                f"accounted: {unit!r}"
-            )
+        if cells[0].endswith("_cleanup_incomplete"):
+            rows.append((cells[0], cells[-1]))
+    return tuple(rows)
+
+
+def _assert_cleanup_incomplete_table_inventory(spec_path=SPEC_PATH):
+    rows = _cleanup_incomplete_reason_code_rows(spec_path)
+    assert tuple(reason_code for reason_code, _ in rows) == (
+        CLEANUP_INCOMPLETE_REASON_CODE_INVENTORY
+    )
+    for reason_code, meaning in rows:
+        assert "pre-commit" in meaning, (
+            f"{reason_code} table row is not pre-commit"
+        )
+        assert "prevented the primary unlink" in meaning, (
+            f"{reason_code} table row does not prevent unlink"
+        )
 
 
 def _assert_retirement_contract(spec_path=SPEC_PATH):
-    section = _retirement_section(spec_path)
+    raw_section = _retirement_section_raw(spec_path)
+    section = " ".join(raw_section.split()).lower()
     missing = [
         name
         for name, statement in REQUIRED_CONTRACTS.items()
@@ -338,27 +258,23 @@ def _assert_retirement_contract(spec_path=SPEC_PATH):
         "SPEC.md retirement coordination is missing contracts: "
         + ", ".join(missing)
     )
-    _assert_no_contradictions(section)
-    _assert_cleanup_incomplete_accounted(
-        spec_path.read_text(encoding="utf-8")
-    )
+    _assert_no_contradictions(raw_section)
+    _assert_cleanup_incomplete_table_inventory(spec_path)
 
 
 def test_retirement_coordination_spec_matches_commit_contract():
     _assert_retirement_contract()
 
 
-def test_cleanup_incomplete_vocabulary_is_precommit_only():
-    section = _retirement_section()
-
-    assert (
-        "cleanup-incomplete reason codes describe only a pre-commit failure"
-        in section
+def test_cleanup_incomplete_inventories_are_canonical():
+    assert _cleanup_incomplete_prose_inventory(
+        _retirement_section_raw()
+    ) == CLEANUP_INCOMPLETE_PROSE_INVENTORY
+    rows = _cleanup_incomplete_reason_code_rows()
+    assert tuple(reason_code for reason_code, _ in rows) == (
+        CLEANUP_INCOMPLETE_REASON_CODE_INVENTORY
     )
-    assert (
-        "a cleanup-incomplete outcome never follows a committed primary unlink"
-        in section
-    )
+    _assert_cleanup_incomplete_table_inventory()
 
 
 def test_cleanup_disclosure_schema_matches_storage_emitter():
@@ -439,12 +355,6 @@ def test_retirement_spec_rejects_unrelated_cleanup_qualifiers(
         )
 
 
-def test_retirement_spec_accepts_only_before_primary_unlink():
-    _assert_cleanup_incomplete_accounted(
-        "Cleanup-incomplete occurs only before the primary unlink."
-    )
-
-
 @pytest.mark.parametrize(
     "contradiction",
     (
@@ -468,14 +378,33 @@ def test_retirement_spec_rejects_cross_occurrence_qualifiers(
 
 
 @pytest.mark.parametrize(
-    "valid_claim",
+    "contradiction",
     (
-        "Only before the primary unlink may cleanup-incomplete occur.",
-        "After a committed primary unlink, cleanup_incomplete cannot occur.",
+        (
+            "Cleanup_incomplete never follows a committed primary unlink and "
+            "may return after a committed primary unlink."
+        ),
+        (
+            "Cleanup_incomplete occurs only before the primary unlink and may "
+            "return after a committed primary unlink."
+        ),
+        (
+            "Only before the primary unlink may cleanup-incomplete occur after "
+            "a committed primary unlink."
+        ),
+        (
+            "After a committed primary unlink, cleanup_incomplete cannot occur "
+            "but may return after a committed primary unlink."
+        ),
     ),
 )
-def test_retirement_spec_accepts_leading_cleanup_qualifiers(valid_claim):
-    _assert_cleanup_incomplete_accounted(valid_claim)
+def test_retirement_spec_rejects_noncanonical_cleanup_claims(
+    contradiction,
+):
+    with pytest.raises(AssertionError, match="contains contradictions"):
+        _assert_no_contradictions(
+            _retirement_section_raw() + "\n" + contradiction
+        )
 
 
 def test_retirement_conflict_docstring_scopes_availability_to_retiring_primary():

--- a/tests/test_issue95_spec_retirement.py
+++ b/tests/test_issue95_spec_retirement.py
@@ -158,7 +158,7 @@ CANONICAL_CLEANUP_INCOMPLETE_TABLES = {
 }
 
 MARKDOWN_ESCAPE_PATTERN = re.compile(r"\\([\\`*_{}\[\]()#+.!|<>-])")
-FENCE_PATTERN = re.compile(r"^\s*(`{3,}|~{3,})")
+FENCE_PATTERN = re.compile(r"^ {0,3}(`{3,}|~{3,})")
 
 
 def _retirement_section_raw(spec_path=SPEC_PATH):
@@ -343,14 +343,24 @@ def _cleanup_incomplete_rows_for_table(text, label):
         if not line.lstrip().startswith("|"):
             break
         table_lines.append(line)
+    table_rows = _markdown_table_rows("\n".join(table_lines))
+    normalized_headers = tuple(
+        _normalize_markdown_surface(cell) for cell in table_rows[0]
+    )
+    assert normalized_headers.count("outcome") == 1
+    outcome_index = normalized_headers.index("outcome")
+    expected_width = len(normalized_headers)
+    assert all(len(cells) == expected_width for cells in table_rows)
     rows = []
-    for cells in _markdown_table_rows("\n".join(table_lines))[2:]:
+    for cells in table_rows[2:]:
         reason_code = _normalize_reason_code(cells[0])
         if reason_code.endswith("_cleanup_incomplete"):
             rows.append(
                 (
                     reason_code,
-                    _normalize_cleanup_incomplete_sentence(cells[-1]),
+                    _normalize_cleanup_incomplete_sentence(
+                        cells[outcome_index]
+                    ),
                 )
             )
     return tuple(rows)
@@ -647,6 +657,45 @@ def test_retirement_spec_rejects_escaped_shadow_reason_code(tmp_path):
     mutated = text.replace(
         git_table_end,
         f"\n{shadow_row}{git_table_end}",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
+
+
+def test_retirement_spec_rejects_extra_cell_hiding_authoritative_outcome(
+    tmp_path,
+):
+    text = SPEC_PATH.read_text(encoding="utf-8")
+    row = next(
+        line
+        for line in text.splitlines()
+        if line.startswith("| `supersession_cleanup_incomplete` |")
+    )
+    cells = [cell.strip() for cell in row.strip("|").split("|")]
+    contradiction = (
+        "Cleanup_incomplete may return after a committed primary unlink."
+    )
+    mutated_row = (
+        f"| {cells[0]} | {contradiction} | {cells[1]} |"
+    )
+    mutated = text.replace(row, mutated_row, 1)
+
+    with pytest.raises(AssertionError):
+        _assert_retirement_contract(_write_mutated_spec(tmp_path, mutated))
+
+
+def test_retirement_spec_rejects_cleanup_prose_after_four_space_fence_marker(
+    tmp_path,
+):
+    text = SPEC_PATH.read_text(encoding="utf-8")
+    contradiction = (
+        "Cleanup_incomplete may return after a committed primary unlink."
+    )
+    mutated = text.replace(
+        SECTION_START,
+        f"{SECTION_START}\n\n    ```\n{contradiction}\n    ```",
         1,
     )
 

--- a/tests/test_v1_115_0.py
+++ b/tests/test_v1_115_0.py
@@ -85,7 +85,12 @@ def test_guarded_delete_match_deletes(tmp_path, monkeypatch):
         family="guarded-delete-unit",
     )
     assert publication
-    assert ds.delete_index("local", "old", expected_fingerprints=fps) is True
+    assert ds.delete_index(
+        "local",
+        "old",
+        expected_fingerprints=fps,
+        retirement_publication=publication,
+    ) is True
     assert ds.load_index("local", "old") is None
 
 

--- a/tests/test_v1_115_0.py
+++ b/tests/test_v1_115_0.py
@@ -19,7 +19,10 @@ from pathlib import Path
 import pytest
 
 from jdocmunch_mcp.storage.doc_store import DocStore, RetirementConflict
-from jdocmunch_mcp.storage.retirements import pending_retirement
+from jdocmunch_mcp.storage.retirements import (
+    begin_retirement,
+    pending_retirement,
+)
 from jdocmunch_mcp.tools import _worktree_corpus as wc
 from tests import test_v1_109_0 as modern
 from tests import test_v1_110_0 as legacy
@@ -69,7 +72,19 @@ def test_guarded_delete_mismatch_raises_and_removes_nothing(tmp_path, monkeypatc
 def test_guarded_delete_match_deletes(tmp_path, monkeypatch):
     _, wt, _, store = legacy._standard_pair(tmp_path, monkeypatch)
     ds = DocStore(base_path=str(store))
-    fps = {"local/old": ds.index_fingerprint("local", "old")}
+    fps = {
+        "local/old": ds.index_fingerprint("local", "old"),
+        "local/modern": ds.index_fingerprint("local", "modern"),
+    }
+    publication = begin_retirement(
+        str(store),
+        "local",
+        "old",
+        retained="local/modern",
+        fingerprints=fps,
+        family="guarded-delete-unit",
+    )
+    assert publication
     assert ds.delete_index("local", "old", expected_fingerprints=fps) is True
     assert ds.load_index("local", "old") is None
 

--- a/tests/test_v1_115_0_qa89.py
+++ b/tests/test_v1_115_0_qa89.py
@@ -169,6 +169,11 @@ def test_qa07_failed_save_preserves_record(tmp_path, monkeypatch):
 def test_qa07_same_process_publishers_never_share_a_temp_path(tmp_path):
     """Two same-process publishers of one record both succeed — the temp
     name is unique per publication, not per PID."""
+    owner_dir = tmp_path / "local"
+    owner_dir.mkdir()
+    for name in ("same", "first", "second"):
+        (owner_dir / f"{name}.json").write_text("{}", encoding="utf-8")
+    store = DocStore(base_path=str(tmp_path))
     results = []
     barrier = threading.Barrier(2)
 
@@ -176,7 +181,11 @@ def test_qa07_same_process_publishers_never_share_a_temp_path(tmp_path):
         barrier.wait(timeout=10)
         results.append(retirements.begin_retirement(
             str(tmp_path), "local", "same",
-            retained=f"local/{label}", fingerprints={f"local/{label}": label},
+            retained=f"local/{label}",
+            fingerprints={
+                "local/same": store.index_fingerprint("local", "same"),
+                f"local/{label}": store.index_fingerprint("local", label),
+            },
             family=label,
         ))
 
@@ -188,7 +197,12 @@ def test_qa07_same_process_publishers_never_share_a_temp_path(tmp_path):
         t.start()
     for t in threads:
         t.join(timeout=15)
-    assert results == [True, True]
+    assert len(results) == 2
+    assert all(
+        isinstance(publication, str) and publication
+        for publication in results
+    )
+    assert results[0] != results[1]
 
 
 # --- QA-08..QA-11 ------------------------------------------------------------

--- a/tests/test_v1_115_0_qa89.py
+++ b/tests/test_v1_115_0_qa89.py
@@ -208,8 +208,7 @@ def test_qa07_same_process_publishers_never_share_a_temp_path(tmp_path):
 # --- QA-08..QA-11 ------------------------------------------------------------
 
 def test_qa08_completed_deletion_never_reported_pending(tmp_path, monkeypatch):
-    """A record whose retiring index no longer exists is a completed
-    retirement — self-healed, never claimed pending."""
+    """Failed cleanup stays visible, then a fresh read self-heals it."""
     from pathlib import Path
 
     _, _, _, store = legacy._standard_pair(tmp_path, monkeypatch)
@@ -222,9 +221,17 @@ def test_qa08_completed_deletion_never_reported_pending(tmp_path, monkeypatch):
             raise OSError("injected finalization failure")
         return real_unlink(path, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "unlink", fail_record_unlink)
-    assert ds.delete_index("local", "old") is True
-    assert ds.load_index("local", "old") is None
+    with monkeypatch.context() as cleanup_failure:
+        cleanup_failure.setattr(Path, "unlink", fail_record_unlink)
+        assert ds.delete_index("local", "old") is True
+        assert ds.load_index("local", "old") is None
+        pending = retirements.pending_retirement(
+            str(store), "local", "old"
+        )
+        assert pending is not None
+        assert pending["publication_id"]
+
+    # A fresh recovery read self-heals once record cleanup is available.
     assert retirements.pending_retirement(str(store), "local", "old") is None
 
 

--- a/tests/test_v1_115_0_qa89.py
+++ b/tests/test_v1_115_0_qa89.py
@@ -15,6 +15,8 @@ direct delete), fsync durability.
 
 from __future__ import annotations
 
+import os
+import stat
 import threading
 
 import pytest
@@ -262,14 +264,54 @@ def test_qa11_record_publication_fsyncs(tmp_path, monkeypatch):
     """The publication receipt promises power-loss durability: the record
     bytes are fsync'd before the atomic replace."""
     _, _, _, store = legacy._standard_pair(tmp_path, monkeypatch)
-    fsync_calls = []
+    fsync_targets = []
     real_fsync = retirements.os.fsync
 
     def record_fsync(fd):
-        fsync_calls.append(fd)
+        mode = os.fstat(fd).st_mode
+        fsync_targets.append(
+            "directory" if stat.S_ISDIR(mode) else "file"
+        )
         return real_fsync(fd)
 
     monkeypatch.setattr(retirements.os, "fsync", record_fsync)
     ds = _begin_pair_retirement(store)
-    assert fsync_calls
+    assert "file" in fsync_targets
+    if os.name != "nt":
+        assert "directory" in fsync_targets
     assert ds.load_index("local", "old") is not None
+
+
+def test_qa11_directory_fsync_failure_returns_no_receipt(
+    tmp_path, monkeypatch
+):
+    _, _, _, store = legacy._standard_pair(tmp_path, monkeypatch)
+    ds = DocStore(base_path=str(store))
+    fingerprints = {
+        "local/old": ds.index_fingerprint("local", "old"),
+        "local/modern": ds.index_fingerprint("local", "modern"),
+    }
+    record_dir = store / "local" / ".retirements"
+    real_open = retirements.os.open
+
+    def fail_directory_open(path, flags, *args):
+        if os.fspath(path) == os.fspath(record_dir):
+            raise OSError("injected directory fsync open failure")
+        return real_open(path, flags, *args)
+
+    monkeypatch.setattr(
+        retirements, "_POSIX_DIRECTORY_FSYNC", True, raising=False
+    )
+    monkeypatch.setattr(retirements.os, "open", fail_directory_open)
+    publication = retirements.begin_retirement(
+        str(store),
+        "local",
+        "old",
+        retained="local/modern",
+        fingerprints=fingerprints,
+        family="legacy_reconcile",
+    )
+
+    assert publication is None
+    assert ds.load_index("local", "old") is not None
+    assert ds.load_index("local", "modern") is not None

--- a/tests/test_v1_115_0_qa90.py
+++ b/tests/test_v1_115_0_qa90.py
@@ -28,12 +28,13 @@ def _pair_with_record(tmp_path, monkeypatch):
         "local/modern": ds.index_fingerprint("local", "modern"),
     }
     assert all(fingerprints.values())
-    assert retirements.begin_retirement(
+    publication = retirements.begin_retirement(
         str(store), "local", "old",
         retained="local/modern", fingerprints=fingerprints,
         family="qa17",
     )
-    return store, ds, fingerprints
+    assert publication
+    return store, ds, fingerprints, publication
 
 
 def test_qa17_retained_delete_refused_inside_final_gate(
@@ -42,7 +43,9 @@ def test_qa17_retained_delete_refused_inside_final_gate(
     """A retained-peer delete landing between the final check and the
     primary unlink is refused, and the retirement completes with the
     retained index intact — never both absent."""
-    store, ds, fingerprints = _pair_with_record(tmp_path, monkeypatch)
+    store, ds, fingerprints, publication = _pair_with_record(
+        tmp_path, monkeypatch
+    )
     retiring_path = ds._index_path("local", "old")
     reached = threading.Event()
     release = threading.Event()
@@ -60,7 +63,10 @@ def test_qa17_retained_delete_refused_inside_final_gate(
     def retire():
         try:
             result["removed"] = ds.delete_index(
-                "local", "old", expected_fingerprints=fingerprints
+                "local",
+                "old",
+                expected_fingerprints=fingerprints,
+                retirement_publication=publication,
             )
         except BaseException as exc:  # pragma: no cover - failure detail
             result["error"] = exc
@@ -98,7 +104,9 @@ def test_qa17_voided_record_conflicts_at_final_gate(tmp_path, monkeypatch):
     """A record voided after entry (retained-peer lifecycle in another
     process) turns the retirement into a conflict at the gate even when
     the fingerprints still match."""
-    store, ds, fingerprints = _pair_with_record(tmp_path, monkeypatch)
+    store, ds, fingerprints, publication = _pair_with_record(
+        tmp_path, monkeypatch
+    )
     record_path = store / "local" / ".retirements" / "old.json"
     real_rmtree_target = ds._content_dir("local", "old")
 
@@ -115,7 +123,12 @@ def test_qa17_voided_record_conflicts_at_final_gate(tmp_path, monkeypatch):
 
     monkeypatch.setattr(doc_store_module.shutil, "rmtree", void_then_rmtree)
     with pytest.raises(RetirementConflict) as exc:
-        ds.delete_index("local", "old", expected_fingerprints=fingerprints)
+        ds.delete_index(
+            "local",
+            "old",
+            expected_fingerprints=fingerprints,
+            retirement_publication=publication,
+        )
     assert exc.value.changed == ["local/modern"]
     assert ds.load_index("local", "old") is not None
     assert ds.load_index("local", "modern") is not None
@@ -127,22 +140,34 @@ def test_qa17_retained_delete_before_gate_voids_and_wins(
     """Before the gate closes, a retained-peer delete voids the record and
     proceeds; the retirement then conflicts and keeps the retiring handle
     — at least one index always survives."""
-    store, ds, fingerprints = _pair_with_record(tmp_path, monkeypatch)
+    store, ds, fingerprints, publication = _pair_with_record(
+        tmp_path, monkeypatch
+    )
     assert DocStore(base_path=str(store)).delete_index(
         "local", "modern"
     ) is True
     assert retirements.pending_retirement(str(store), "local", "old") is None
     with pytest.raises(RetirementConflict):
-        ds.delete_index("local", "old", expected_fingerprints=fingerprints)
+        ds.delete_index(
+            "local",
+            "old",
+            expected_fingerprints=fingerprints,
+            retirement_publication=publication,
+        )
     assert ds.load_index("local", "old") is not None
 
 
 def test_qa17_completed_gate_leaves_no_pending_record(tmp_path, monkeypatch):
     """The record is removed inside the gate: the moment the guarded delete
     returns, no observer can see index-gone-but-record-pending."""
-    store, ds, fingerprints = _pair_with_record(tmp_path, monkeypatch)
+    store, ds, fingerprints, publication = _pair_with_record(
+        tmp_path, monkeypatch
+    )
     assert ds.delete_index(
-        "local", "old", expected_fingerprints=fingerprints
+        "local",
+        "old",
+        expected_fingerprints=fingerprints,
+        retirement_publication=publication,
     ) is True
     assert retirements.pending_retirement(str(store), "local", "old") is None
     assert (store / "local" / ".retirements" / "old.json").exists() is False


### PR DESCRIPTION
Implements the remaining Issue #95 Path A changes: QA-19 commit-scoped
authority, QA-23 caller-derived wait policy, QA-21 lockfile preservation, the
public `reason_code` contract and drift guard, and QA-25 verification.
`[1.115.0]` remains the CHANGELOG section label; the shipped version will be
`1.120.0` or later.

### QA-19: authority is now commit-scoped

Four separate rules, each identifiable in the diff:

**Publication identity.** `begin_retirement` returns a `secrets.token_hex(16)`
receipt, written into the record and re-read under the record lock before the
receipt is handed back. A record pathname identifies a slot; the receipt
identifies one publication.

**Proof after retained coordination.** The final gate takes the record lock,
then the retained handle's gate nonblockingly, and only *then* re-verifies
fingerprints and re-reads the publication. Everything before the gate is fast
rejection. Both locks are held through the unlink and publication-scoped
completion.

**The proof is bound to the publication and its exact retirement pair, not to
the caller.** The gate verifies the fingerprint map stored *in the record*,
requires the caller's copy to equal it, and requires exactly the retiring and
retained handles with non-empty fingerprints. The record must also name the
requested retiring slot and a distinct, safe retained handle. Without these
checks, a caller holding a valid receipt could omit one side of the pair or
present internally consistent authority for the wrong pair.

**Conditional record mutation.** Publication, completion, conflict cleanup,
reverse-scan voiding and stale self-healing all revalidate under the record
lock and act only on their own publication. `hold_record_lock` now raises
`RetirementRecordLockError` rather than yielding without a lock, and every
authoritative path treats that as fail-closed.

### QA-23: caller-derived wait policy

`try_void_retirements_referencing` receives `timeout_seconds=1.0 if lock_wait
else 0.0`. Public deletion makes one immediate attempt and returns typed busy
with no retry sleep; internal retirement keeps its bounded one-second budget.
Measured on the installed wheel: **0.4 ms** and **0.9 ms** against the
harness's 500 ms ceiling.

### QA-21, QA-25, and the public vocabulary

Normal deletion preserves the per-index lockfile, proven on real Linux by
`test_delete_does_not_unlink_the_lockfile` and
`test_three_processes_keep_one_lock_inode`, both executed rather than skipped.

QA-25 remains verification-only. `test_v1_115_0_qa25.py` is unmodified.

One runtime vocabulary for `index_deleted`, `index_not_found` and
`index_lifecycle_busy`, published as a `SPEC.md` table and drift-guarded
against the real emitter and the public tool.

### Durability and lock availability

QA-11's requested power-loss durability is implemented for a successful
publication. The record file is flushed, atomically replaced, the parent
directory is flushed on POSIX, and the exact publication is re-read under the
record lock. No receipt is returned, and no deletion may begin, unless every
step succeeds.

One narrow, fail-closed limitation is intentionally deferred from this arc. If
the atomic replacement becomes visible but the following directory flush
reports an error, the filesystem has not confirmed whether that directory entry
would survive power loss. `begin_retirement()` therefore returns no receipt, no
primary unlink is attempted, and both indexes remain loadable. The immediate
operation does not claim a pending retirement. If the readable record does
persist, a later recovery query may report it pending until coordinated
publication or voiding replaces or removes it. It still cannot authorize
deletion without the exact current publication, retiring/retained pair,
retained-handle gate, and final fingerprint proof.

Unlinking the record in that handler would not restore the power-loss guarantee.
The unlink changes the same directory and requires the same successful
directory flush to become durable. A best-effort unlink could hide the record
in the running process without proving that its removal would survive a crash.
A stronger quarantine protocol is possible, but it would require an explicit
recovery state machine for indeterminate storage outcomes, its own durable
authority, and retry rules. If that additional defense is desired, it should be
evaluated as a separate storage-recovery enhancement, not as a blocker to
closing this arc.

On a supported local POSIX filesystem, a directory-flush error is exceptional
rather than an expected operating condition. On a filesystem that does not
support the required directory-flush semantics, retirement refuses repeatably.
The component-level failure is fail-closed: neither index is deleted,
retirement is refused, and the worst residual state is a readable pending
record that can be replaced or voided when the retirement operation is retried
successfully.

The injected-failure test directly proves that no receipt is returned and both
indexes remain loadable. Separate tests cover publication identity, pair
binding, the retained-handle gate, and final-fingerprint enforcement. There is
no single end-to-end test that begins with this injected directory-flush failure
and then exercises later replacement or voiding.

When neither supported cross-process lock primitive exists, guarded retirement
and retained-peer deletion refuse rather than enter an unlocked critical
section. The general index write lock is deliberately unchanged: that boundary
was closed at retirement authority rather than by redesigning storage locking,
which would have been a far wider change than this arc.

### Non-vacuity evidence

Tests are graded by whether they demonstrate behavior at their comparison
commit, not merely by whether they fail.

**The strongest evidence is the pre-registered harness, not the tests I wrote
alongside the fix.** I re-ran `qa_lifecycle_contract.py` unmodified against
`3709d21`:

```
4 failed, 3 passed
  test_refresh_completed_before_commit_invalidates_retirement_proof[full]
  test_refresh_completed_before_commit_invalidates_retirement_proof[incremental]
  test_late_retained_delete_cannot_remove_both
  test_public_record_lock_contention_is_prompt
```

This matches the 3-passed/4-failed pre-fix receipt
[published in #95](https://github.com/jgravelle/jdocmunch-mcp/issues/95)
(measured there at `99a31c1`), and it is 7/7 on the current tree. The harness
is unchanged and predates this implementation.

**Behavioural failures against `3709d21`.** These three fail because the old
code declines to refuse, not because an API is missing:

- `test_guarded_delete_requires_a_current_publication`: `DID NOT RAISE RetirementConflict`
- `test_guarded_delete_cannot_adopt_a_replacement_publication`: `DID NOT RAISE RetirementConflict`
- `test_authoritative_record_lock_never_yields_without_a_lock`: `Failed: critical section entered without an authoritative lock`

**Behavioural failures against intermediate commits in this pull request.** These
tests found defects after the relevant APIs existed:

| Test | Red at | Old behaviour |
|---|---|---|
| `test_empty_expected_fingerprints_never_authorize_a_delete` | `6565b16` | valid receipt plus empty proof returned `True` and removed the index |
| `test_partial_proof_cannot_hide_a_changed_retained_peer` | `6565b16` | partial proof committed while the retained peer had changed |
| `test_drive_relative_handle_never_escapes_the_store` | `a16d2b5` | `C:../escape` hashed a file outside the store |

**Weak by this standard, and labelled as such.** The remaining new tests
exercise APIs introduced by this pull request (`retirement_publication`,
`publication_id`, `retirement_record`, `_fingerprint_handle`,
`is_safe_path_component`), so against `3709d21` they fail with
`TypeError`/`AttributeError` rather than on behaviour. That includes
`test_publication_receipt_is_unique_and_persisted` and
`test_older_completion_cannot_remove_newer_publication`, which describe real
pre-fix gaps but do not *demonstrate* them at that commit. They are coverage
for the new contract; I am not offering them as proof the old code was broken.

**Drift guards, which pass pre-fix by design** and are not regressions at all:
`test_proof_and_record_side_fingerprints_are_one_implementation`,
`test_altered_proof_values_are_refused`, and the component-policy sweep.

### Validation of this exact tree

The current candidate is
`03d9762263e15783eedddb9d5d79658b5005c727`. These are local results, not
GitHub CI receipts.

The Linux rows and NumPy-installed Windows row were measured at `63eede0`.
`src/`, `tests/`, `SPEC.md` and `pyproject.toml` are byte-identical at
`03d9762`. The frozen harness, Replay gate, and no-NumPy Windows full suite were
rerun at `03d9762`. The pre-rebase commit is preserved on my fork as tag
`pr95-prerebase-63eede0`, so the carry-over is checkable:

```
git fetch https://github.com/rknighton/jdocmunch-mcp.git \
  refs/tags/pr95-prerebase-63eede0
git diff 63eede0 03d9762 -- src/ tests/ SPEC.md pyproject.toml
(empty)
```

| Check | Result |
|---|---|
| Frozen harness `qa_lifecycle_contract.py`, at `03d9762` | SHA-256 unchanged; 7/7 |
| Replay gate, at `03d9762` | **26/26** |
| Frozen harness, consecutive runs | Windows 7/7, Linux 35/35 |
| Windows 11, Python 3.13, full suite, no NumPy, at `03d9762` | **1957 passed, 14 skipped, 0 failed** |
| Windows 11, Python 3.13, full suite, NumPy installed | **1963 passed, 8 skipped, 0 failed** |
| Linux, Python 3.12, focused Issue #95 suite | **120 passed, 2 skipped, 0 failed** |
| Linux, Python 3.12, full suite | **1968 passed, 3 skipped, 0 failed** |
| Linux-specific coordination suite | **9 executed, 0 skipped** |
| sdist + wheel build, `pip check` | clean |

Linux ran in a network-isolated container on a real POSIX filesystem, from a
verified git bundle, with `AGENTS.md` and local review state asserted absent.
Those counts came from a clean checkout, never a working tree.

Exact-head Windows validation used a dedicated clean worktree at `03d9762`.

On the Linux full-suite skip count: the run skips the two pair-lock (Path B)
tests, correctly inapplicable while Path A stands, plus a Windows-casing test.

The two Windows rows collected the same 1,971 tests and differ by exactly six:
the optional NumPy cases, which pass when NumPy is installed and skip when it is
not. Both completed with zero failures.

### Known limitations and decisions

#### Retained-gate cost

Moving authoritative proof inside the retained gate is not free. Median,
uncontended, Windows/NTFS:

| 2 MB monolith | Baseline | Final candidate |
|---|---:|---:|
| record-lock hold | 3.13 ms | 3.02 ms |
| **retained-gate hold** | **0.56 ms** | **2.81 ms** |

The outer record lock is unchanged, because it already covered a fingerprint
verification. The retained gate, which is what a writer on the retained
peer actually queues behind, grew about 5x at 2 MB and scales linearly with
corpus size. The pre-fix exposure window this closes measured 0.18–0.28 ms.

If that hold time is material for the corpus sizes you expect, it is worth a
conversation before merge. This retained-gate serialization cost does not
apply to the public deletion path.

#### Evidence and follow-up boundaries

- **No GitHub CI result exists for this PR head.** The workflows gate `push` and
  `pull_request` on `master`, so a PR into `coordinated-retirement` does not
  fire them.
- **This submission is not the independent re-verification the release gate
  requires.** The author of an implementation cannot be its skeptic. The
  unchanged pre-registered `qa_lifecycle_contract.py` remains the evidence that
  predates the implementation. That commitment and its release-note wording are
  recorded in
  [#95](https://github.com/jgravelle/jdocmunch-mcp/issues/95#issuecomment-5091742899).
- **Python 3.10 and installed-wheel results are historical, not exact-head
  evidence.** They are not used to claim validation of the latest correction
  commits; final exact-SHA package and CI evidence remains an integration
  step.
- **Real-process interruption tests remain in this pull request.** QA-19
  requires truthful outcomes across abrupt process termination, which mocked
  exceptions cannot demonstrate. The tests use `os._exit` only in spawned
  processes.
- **The `CONTENTION_SENSITIVE` guard does not inventory new test files.** An
  AST audit confirms that every contention-sensitive call in the six new test
  files passes `lock_wait` explicitly. Broadening the guard is deferred because
  current behavior is covered and the remaining issue is guard maintenance,
  not a runtime gap.
- **A commit SHA does not describe untracked working-tree state.** Validation
  claims above identify clean checkouts or worktrees. CI necessarily exercises
  a clean checkout, so QA-24 should keep those experiments distinct rather
  than treating the SHA alone as complete provenance.
- **The counts above are hand-transcribed, not machine-generated.** The
  generated exact-SHA evidence summary belongs to the frozen-SHA run, since a
  receipt is only as trustworthy as the system that produced it. These local
  results are labelled as such and are not offered as that summary.

#### Questions you left open

**[Should uncontended `delete_index` call sites also state `lock_wait`?](https://github.com/jgravelle/jdocmunch-mcp/issues/95#issuecomment-5083764940)**
No. Your narrowing was right: requiring the flag where the caller is the first
acquirer adds noise without changing an outcome. The one caveat is the guard's
coverage of new test files, above.

**[Does a green frozen-SHA CI run say anything about untracked working-tree state?](https://github.com/jgravelle/jdocmunch-mcp/issues/95#issuecomment-5083798778)**
No, and I hit that trap myself while preparing this. The working-tree boundary
above records the standard I drew from it.

### CI handoff

`fail-fast: false` is already present in the Tests matrix at the base commit,
so one failing matrix job will not cancel the others. Your
[all-nine-green run at `65ad9a0`](https://github.com/jgravelle/jdocmunch-mcp/issues/95#issuecomment-5092821807)
establishes the target base for this PR. The remaining external evidence item
is a successful Tests and Replay result whose recorded `headSha` equals the
integrated candidate.

This PR is the review, provenance and CLA vehicle. Once you place the candidate
on `coordinated-retirement`,
[draft PR #92](https://github.com/jgravelle/jdocmunch-mcp/pull/92) remains the
held integration and merge vehicle into `master`. If its `synchronize` event
produces exact-head runs, those results can be used. Otherwise, the Tests and
Replay workflows can be dispatched manually against `coordinated-retirement`,
with each recorded `headSha` required to equal the integrated candidate. I
have not opened anything against `master`.

The history is intentionally unsquashed so each commit remains independently
reviewable. Happy to squash if you would rather.

CLA: signing on prompt.
