### PR TITLE
jdoc#118: run the embedding import in a child process, on by default

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "jdocmunch",
   "displayName": "jDocMunch",
-  "version": "1.132.0",
+  "version": "1.133.0",
   "description": "Token-efficient MCP server for structured documentation retrieval via section-level indexing",
   "author": {
     "name": "J. Gravelle",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## [1.133.0] - 2026-08-13 - The embedding import leaves the server, and the choice goes with it
+
+[#118](https://github.com/jgravelle/jdocmunch-mcp/issues/118) closed properly.
+`sentence-transformers` now loads in a **child process**, on by default.
+
+v1.132.0 shipped a switch, not a fix, and said so: the import was either on the
+main thread (a cold `torch` load measured **73.77 s**, past a client's 30 s
+connect timeout) or on a background thread (Windows loader lock, wedged
+indefinitely). Both contracts cannot hold in one process — so the process was
+the thing to change. The import now runs concurrently with the live server
+**and** alone in its own loader, which makes backgrounding safe again.
+
+**The default is the fix.** Leaving the worker opt-in would have added a third
+switch to a pile of two and left the user picking between outages, which is the
+defect restated as configuration. `JDOCMUNCH_EMBED_WORKER=0` opts out;
+`JDOCMUNCH_PRELOAD_EMBEDDINGS=1` still selects v1.132.0's main-thread import for
+anyone who chose it.
+
+Measured here (deltas, not absolutes): `initialize` with the worker is
+**indistinguishable from the in-process default** — +0.04 s across three runs,
+inside run-to-run noise — against **+5.6 s** for the v1.132.0 preload; 1000 sections embed in **1.72 s**
+through the pipe against **1.64 s** in-process. The handshake cost is a spawn,
+not an import, so it does not grow on a healthy install.
+
+**What crosses the boundary is one method**, `embed_texts`. Provider detection,
+the HuggingFace-cache probe, cache keys, the sidecar, identity headers and
+rotation detection all need no import and stay in the server. numpy stays too —
+`doc_store` and `related_persist` use it to *score*, and a section matrix down a
+pipe per query would be absurd; the existing numpy preload still covers them.
+The server now loads numpy and nothing else native.
+
+Details that are load-bearing rather than incidental:
+
+- **A spawn failure falls back to the in-process provider.** Without that,
+  defaulting the worker on would silently remove semantic search from machines
+  with an unusual `sys.executable` — a new defect traded for the old one. A
+  child that dies *later* does not fall back, because by then the machine has
+  proven it can spawn and importing the stack into a running server would trade
+  a degraded feature for the deadlock.
+- **The cache identity is unchanged.** `_provider_identity` still reports `None`
+  for this provider's dim; adopting the child's reported dim would fail
+  `identity_matches` on every existing sidecar and re-embed every corpus.
+- **A timeout raises** rather than returning empty vectors, so `embed_sections`
+  records `embed_failed` and preserves the sidecar. Requests chunk at 256,
+  because `embed_sections` submits every cache miss in one call.
+- **A wedged child is killed.** That is the property a thread cannot offer, and
+  the reason this is a fix rather than a relocation.
+- The child claims a private stdout for its protocol, inherits stderr, and exits
+  when the server does. It opens no network connection and registers nothing —
+  disclosed in the README's new "Background behavior, fully disclosed" section.
+
+⚠ **The wedge itself still does not reproduce on the machine that reported it**,
+so there is no A/B and this does not claim one. What is asserted instead is
+stronger and deterministic: after a real embed, the server process's
+`sys.modules` contains none of `sentence_transformers`, `transformers`, `torch`,
+`scipy` or `sklearn`. The deadlock is unreachable rather than unobserved.
+
 ## [1.132.0] - 2026-08-12 - The loader deadlock has a stack, and the fix has a price tag
 
 [#118](https://github.com/jgravelle/jdocmunch-mcp/issues/118) named at last, with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # jdocmunch-mcp
 
-**Version:** 1.132.0 |
+**Version:** 1.133.0 |
 **Tests:** `PYTHONPATH=src pytest tests/ -q`
 
 ⚠ **`tests/` is shipped inside the sdist, so anything dropped there is
@@ -38,14 +38,31 @@ a count into this file. **The `coordinated-retirement` hold is OVER** — #92
 merged as `3037428`, branch deleted from the workflow. Nothing is held; ship
 from `master`.
 
-## UNRELEASED, branch `feat/jdoc-118-embed-worker` — #118 phase 1: the import moves to a child
+## v1.133.0 — #118 CLOSED: the import leaves the server, and the choice goes with it
 
-⚠⚠ **This is the exit #118 named for itself**, and it is OPT-IN and UNRELEASED.
-`JDOCMUNCH_EMBED_WORKER=1` runs sentence-transformers in a child process, so the
-import is concurrent with the live server AND alone in its own loader.
-**Backgrounding becomes safe again because the concurrency leaves the loader that
-deadlocks** — which is the only way out of v1.132.0's structural collision
-(main thread ⇒ slow handshake, background thread ⇒ possible indefinite hang).
+⚠⚠ **This is the exit #118 named for itself, and it is ON BY DEFAULT.**
+sentence-transformers runs in a child process, so the import is concurrent with
+the live server AND alone in its own loader. **Backgrounding becomes safe again
+because the concurrency leaves the loader that deadlocks** — the only way out of
+v1.132.0's structural collision (main thread ⇒ slow handshake, background thread
+⇒ possible indefinite hang).
+
+⚠⚠ **THE DEFAULT IS THE FIX, and shipping it opt-in was a mistake caught in
+review.** The first cut of this was `JDOCMUNCH_EMBED_WORKER=1`, off by default —
+i.e. **a third switch on a pile of two, leaving the user picking between
+outages, which is exactly why #118 stayed open after v1.132.0.** A fix the
+reporter has to opt into has not resolved their issue; it has documented it.
+`JDOCMUNCH_EMBED_WORKER=0` opts out and `JDOCMUNCH_PRELOAD_EMBEDDINGS=1` still
+selects v1.132.0's main-thread import, so nobody loses a choice they made — but
+nobody has to make one.
+
+⚠⚠ **Defaulting it required the spawn-failure fallback FIRST.** A child that
+cannot be spawned (odd `sys.executable`, frozen bundle, locked-down sandbox)
+would otherwise silently remove semantic search from machines where it works
+today — **a NEW defect traded for #118's**, which is not a trade to make on a
+user's behalf. ⚠ A child that dies LATER does not fall back: by then the machine
+has proven it can spawn, and importing the stack into a running multi-threaded
+server would trade a degraded feature for the deadlock.
 
 ⚠ **One method crosses the boundary**: `embed_texts`. Provider detection, the
 HF-cache probe, cache keys, the sidecar, identity headers and rotation detection
@@ -79,13 +96,18 @@ that imports sklearn.
 the remedy — an explicit `_INTENTIONAL_STDIN_PIPE` entry with a reason, never a
 loosened rule, plus a test that the exempted module really does pass PIPE.
 
-Measured here, healthy install, delta not absolute (jdoc#114): `initialize`
-+**0.13 s** for the worker vs +**5.99 s** for 1.132.0's `JDOCMUNCH_PRELOAD_EMBEDDINGS`.
+Measured here, healthy install, delta not absolute (jdoc#114): `initialize` with
+the worker is **inside run-to-run noise of the in-process default** (+0.04 s over
+3 runs) vs +**5.6 s** for 1.132.0's `JDOCMUNCH_PRELOAD_EMBEDDINGS`. ⚠ The cost is
+a SPAWN, not an import, so it does not grow on a healthy install.
 1000 sections **1.72 s** through the pipe vs **1.64 s** in-process (base64 float32,
 ~5%). Real 384-dim vector end to end in 8.62 s cold. ⚠ **The wedge itself is still
 not reproducible on this box**, which is exactly why the `sys.modules` guard exists.
-⚠ **Shipping this adds a persistent child process — README-disclose BEFORE release**
-(the PyPI quarantine rule). Suite **2533 / 6**.
+⚠ This adds a child process, so it is README-disclosed under the PyPI-quarantine
+rule — new "Background behavior, fully disclosed" section, written BEFORE release.
+⚠ **Four version pin sites, and the fourth is `.claude-plugin/plugin.json`** — the
+suite caught it, which is the only reason it is not still at 1.132.0.
+Suite **2538 / 6**.
 
 ## v1.132.0 — #118: the loader deadlock has a stack, and the fix has a price tag
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,55 @@ a count into this file. **The `coordinated-retirement` hold is OVER** — #92
 merged as `3037428`, branch deleted from the workflow. Nothing is held; ship
 from `master`.
 
+## UNRELEASED, branch `feat/jdoc-118-embed-worker` — #118 phase 1: the import moves to a child
+
+⚠⚠ **This is the exit #118 named for itself**, and it is OPT-IN and UNRELEASED.
+`JDOCMUNCH_EMBED_WORKER=1` runs sentence-transformers in a child process, so the
+import is concurrent with the live server AND alone in its own loader.
+**Backgrounding becomes safe again because the concurrency leaves the loader that
+deadlocks** — which is the only way out of v1.132.0's structural collision
+(main thread ⇒ slow handshake, background thread ⇒ possible indefinite hang).
+
+⚠ **One method crosses the boundary**: `embed_texts`. Provider detection, the
+HF-cache probe, cache keys, the sidecar, identity headers and rotation detection
+all need no import and stay put. ⚠⚠ **numpy STAYS in the server** — `doc_store`
+and `related_persist` use it to SCORE, and a section matrix down a pipe per query
+is absurd; `preload_native_deps()` still covers them and is unchanged. End state:
+the server loads numpy and nothing else native.
+
+⚠⚠ **The identity header is deliberately NOT given the dim the child reports.**
+`_provider_identity` returns `None` for sentence-transformers and the cache reads
+that as a wildcard; filling it in would fail `identity_matches` on every sidecar
+written before this change — **jdoc#109's corpus-wide re-embed, triggered by a
+refactor instead of a rotation.** Pinned by a test.
+
+⚠ **A timeout is what makes this a fix and not a relocation.** A thread wedged in
+`LdrLoadDll` is a kernel-mode wait that no timeout, thread-kill or try/except can
+touch; a process is killable. Timeouts RAISE rather than returning empty vectors —
+`embed_sections` reads an exception as `embed_failed` and preserves the sidecar,
+while empty vectors read as "this corpus has none" (jdoc#107/#109's shape).
+Requests are chunked at 256 because `embed_sections` hands over every cache miss
+in ONE call, so an unchunked request has no timeout that is both survivable and
+meaningful.
+
+⚠ **The guard that can close #118 without reproducing the race:** after a real
+embed, the parent's `sys.modules` holds none of sentence_transformers / transformers
+/ torch / scipy / sklearn. That proves the deadlock **unreachable** rather than
+observing it did not fire this time. Detector proven non-vacuous against a probe
+that imports sklearn.
+
+⚠ `test_subprocess_stdin_guard` FAILED on `stdin=PIPE` and its own docstring named
+the remedy — an explicit `_INTENTIONAL_STDIN_PIPE` entry with a reason, never a
+loosened rule, plus a test that the exempted module really does pass PIPE.
+
+Measured here, healthy install, delta not absolute (jdoc#114): `initialize`
++**0.13 s** for the worker vs +**5.99 s** for 1.132.0's `JDOCMUNCH_PRELOAD_EMBEDDINGS`.
+1000 sections **1.72 s** through the pipe vs **1.64 s** in-process (base64 float32,
+~5%). Real 384-dim vector end to end in 8.62 s cold. ⚠ **The wedge itself is still
+not reproducible on this box**, which is exactly why the `sys.modules` guard exists.
+⚠ **Shipping this adds a persistent child process — README-disclose BEFORE release**
+(the PyPI quarantine rule). Suite **2533 / 6**.
+
 ## v1.132.0 — #118: the loader deadlock has a stack, and the fix has a price tag
 
 **A subprocess probe cannot fix a deadlock.** `py-spy dump --native` on a wedged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ not reproducible on this box**, which is exactly why the `sys.modules` guard exi
 rule — new "Background behavior, fully disclosed" section, written BEFORE release.
 ⚠ **Four version pin sites, and the fourth is `.claude-plugin/plugin.json`** — the
 suite caught it, which is the only reason it is not still at 1.132.0.
-Suite **2538 / 6**.
+Suite **2539 / 6**.
 
 ## v1.132.0 — #118: the loader deadlock has a stack, and the fix has a price tag
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,26 @@ JDOCMUNCH_SHARE_SAVINGS=0
 
 Embedding and summarizer providers call their configured API **only when you enable them**, and never by default. `watch-install` registers a login service **only** when you run it yourself.
 
+### Background behavior, fully disclosed
+
+**A child process, when local embeddings are in use.** When the
+`sentence-transformers` provider is active, jDocMunch runs the embedding model
+in a **child process** (`python -m jdocmunch_mcp.embeddings.worker`) instead of
+inside the server. It:
+
+- starts when something first needs an embedding — at startup if the model is
+  already in your local HuggingFace cache, otherwise on the first search or
+  index that uses it. A lexical-only install never spawns it;
+- opens **no network connection** and speaks only to its parent, over a private pipe;
+- exits when the server exits, and is killed if it stops responding;
+- is **not** a login service, is not registered anywhere, and survives nothing.
+
+This exists because importing the embedding stack inside the server process can
+deadlock in the Windows loader
+([#118](https://github.com/jgravelle/jdocmunch-mcp/issues/118)), hanging every
+tool call for as long as the server runs. Disable it with
+`JDOCMUNCH_EMBED_WORKER=0`, which restores the previous in-process import.
+
 Path traversal prevention, symlink escape protection, secret exclusion, file-size limits, binary detection, and encoding safety are documented in [SECURITY.md](SECURITY.md), along with how to report a vulnerability.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jdocmunch-mcp"
-version = "1.132.0"
+version = "1.133.0"
 description = "Token-efficient MCP server for structured documentation retrieval via section-level indexing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.jgravelle/jdocmunch-mcp",
   "title": "jDocmunch MCP",
   "description": "Section-level doc search for .md, .rst, .adoc, .ipynb, .html, .yaml, .json, and OpenAPI specs.",
-  "version": "1.132.0",
+  "version": "1.133.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "jdocmunch-mcp",
-      "version": "1.132.0",
+      "version": "1.133.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/jdocmunch_mcp/embeddings/provider.py
+++ b/src/jdocmunch_mcp/embeddings/provider.py
@@ -494,7 +494,23 @@ def _sentence_transformers_factory():
     """
     if _embed_worker_enabled():
         from . import worker as _worker
-        return _worker.WorkerProvider(_st_model_name())
+        instance = _worker.WorkerProvider(_st_model_name())
+        if not getattr(instance, "spawn_failed", False):
+            return instance
+        # ⚠⚠ The guard that makes defaulting the worker ON safe. If the child
+        # could not be spawned at all — no interpreter at `sys.executable`, a
+        # frozen bundle, a sandbox that forbids it — then degrading to lexical
+        # would silently remove semantic search from machines where it works
+        # today. That is a NEW defect traded for jdoc#118's, which is not a
+        # trade worth making by default. Nothing has been learned about the
+        # import here, so the in-process provider is exactly as safe as it was
+        # before this change.
+        logger.warning(
+            "the embedding worker could not be started; falling back to the "
+            "in-process provider. On Windows this restores the jdoc#118 "
+            "deadlock exposure — set JDOCMUNCH_PRELOAD_EMBEDDINGS=1 to import "
+            "the stack on the main thread instead."
+        )
     return _SentenceTransformersProvider()
 
 

--- a/src/jdocmunch_mcp/embeddings/provider.py
+++ b/src/jdocmunch_mcp/embeddings/provider.py
@@ -465,11 +465,44 @@ class _SentenceTransformersProvider:
 # only via _get_provider().
 # ---------------------------------------------------------------------------
 
+def _embed_worker_enabled() -> bool:
+    """Whether sentence-transformers should be run out of process (jdoc#118).
+
+    ⚠ Imported lazily and failing closed: :mod:`worker` must never become a
+    hard dependency of provider detection, which runs on the startup path.
+    """
+    try:
+        from . import worker as _worker
+    except Exception:  # pragma: no cover - defensive
+        return False
+    try:
+        return _worker.worker_enabled()
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
+def _sentence_transformers_factory():
+    """Build the sentence-transformers provider, in this process or a child.
+
+    jdoc#118 phase 1: ``JDOCMUNCH_EMBED_WORKER=1`` swaps the implementation and
+    nothing else — same interface, same cache keys, same identity header. ⚠ The
+    identity is deliberately NOT changed to carry the dim the child reports:
+    ``_provider_identity`` returns ``None`` for this provider and the cache
+    treats that as a wildcard, so filling it in would flip
+    ``identity_matches`` and re-embed every existing corpus on first run
+    (jdoc#109's escalation, triggered by a refactor rather than a rotation).
+    """
+    if _embed_worker_enabled():
+        from . import worker as _worker
+        return _worker.WorkerProvider(_st_model_name())
+    return _SentenceTransformersProvider()
+
+
 _PROVIDER_FACTORIES: dict = {
     "gemini": _GeminiProvider,
     "openai": _OpenAIProvider,
     "openai-compatible": _OpenAICompatibleProvider,
-    "sentence-transformers": _SentenceTransformersProvider,
+    "sentence-transformers": _sentence_transformers_factory,
 }
 
 # Cache: {(provider_name, model_signature): provider_instance}
@@ -521,7 +554,17 @@ def _get_provider():
     # library load in this process. Cached, so this costs one subprocess at most
     # once per process — and only on the path that was about to pay for the
     # import anyway.
-    if name == "sentence-transformers" and not _sentence_transformers_imports_cleanly():
+    #
+    # ⚠ Skipped entirely when the worker is enabled: this process never imports
+    # sentence-transformers, so there is nothing here to protect, and the
+    # worker's own ready handshake is a strictly better probe — it tests the
+    # long-lived child that will do the work rather than a short-lived one that
+    # merely resembles it.
+    if (
+        name == "sentence-transformers"
+        and not _embed_worker_enabled()
+        and not _sentence_transformers_imports_cleanly()
+    ):
         logger.warning(
             "sentence-transformers is installed but could not be imported in a "
             "probe subprocess (%s); embeddings are unavailable. Lexical search "
@@ -852,7 +895,11 @@ def warmup() -> str:
     # in-process attempt that deadlocks in the native loader is unkillable and
     # poisons every subsequent library load in this process, so a failure here
     # is not confined to embeddings — it takes the whole server with it.
-    if not _sentence_transformers_imports_cleanly():
+    #
+    # ⚠ With the worker enabled the import happens in a child, so warming is
+    # both safe and worth doing on this daemon thread: the wait is bounded and
+    # the child, unlike a wedged thread, can be killed.
+    if not _embed_worker_enabled() and not _sentence_transformers_imports_cleanly():
         logger.warning(
             "skipping embedding warmup: sentence-transformers could not be "
             "imported in a probe subprocess (%s). Lexical search is "

--- a/src/jdocmunch_mcp/embeddings/worker.py
+++ b/src/jdocmunch_mcp/embeddings/worker.py
@@ -210,6 +210,7 @@ class WorkerProvider:
         #: on a machine where today it works. See
         #: ``provider._sentence_transformers_factory``.
         self.spawn_failed = False
+        self._atexit_registered = False
         if spawn:
             try:
                 self._spawn()
@@ -281,6 +282,14 @@ class WorkerProvider:
             daemon=True,
         )
         reader.start()
+        if not self._atexit_registered:
+            # Short-lived callers matter here as much as the server: the
+            # PostToolUse reindex hook is a whole process per edited file, and
+            # leaving each one's child to be collected by interpreter teardown
+            # produces ResourceWarnings and a window where it is still running.
+            import atexit
+            atexit.register(self.close)
+            self._atexit_registered = True
         self._send({"op": "ready", "model": self._model_name})
 
     @staticmethod
@@ -347,6 +356,24 @@ class WorkerProvider:
             if predicate(reply):
                 return reply
 
+    @staticmethod
+    def _close_pipes(proc: subprocess.Popen) -> None:
+        """Close the child's pipes once it has exited.
+
+        Popen does not do this for us, and leaving them to interpreter teardown
+        raises ResourceWarning in short-lived callers (the reindex hook is one
+        process per edited file). The reader thread may be mid-iteration on
+        stdout; it catches the resulting error and stops, which is what we want
+        anyway.
+        """
+        for stream in (proc.stdin, proc.stdout):
+            if stream is None:
+                continue
+            try:
+                stream.close()
+            except Exception:
+                pass
+
     def _kill(self, reason: str) -> None:
         """Terminate the child. ⚠ This is the property a thread cannot offer.
 
@@ -361,13 +388,16 @@ class WorkerProvider:
         if proc is None:
             return
         logger.warning("killing the embedding worker: %s", reason)
-        for step in (proc.terminate, proc.kill):
-            try:
-                step()
-                proc.wait(timeout=5)
-                return
-            except Exception:
-                continue
+        try:
+            for step in (proc.terminate, proc.kill):
+                try:
+                    step()
+                    proc.wait(timeout=5)
+                    return
+                except Exception:
+                    continue
+        finally:
+            self._close_pipes(proc)
 
     def close(self) -> None:
         """Ask the child to exit, then make sure it did."""
@@ -379,6 +409,7 @@ class WorkerProvider:
                 self._send({"op": "shutdown"})
                 proc.wait(timeout=5)
                 self._proc = None
+                self._close_pipes(proc)
                 return
             except Exception:
                 pass

--- a/src/jdocmunch_mcp/embeddings/worker.py
+++ b/src/jdocmunch_mcp/embeddings/worker.py
@@ -57,6 +57,7 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 _ENABLED = ("1", "true", "yes", "on")
+_DISABLED = ("0", "false", "no", "off")
 
 #: Texts per request. Bounds both the child's peak memory and, more
 #: importantly, the per-request timeout: ``embed_sections`` hands over every
@@ -85,13 +86,31 @@ class EmbedWorkerError(RuntimeError):
 
 
 def worker_enabled() -> bool:
-    """Whether sentence-transformers should run out of process.
+    """Whether sentence-transformers should run out of process. **On by default.**
 
-    Off unless explicitly on. Phase 1 changes no default: the in-process
-    provider, the jdoc#118 probe and the jdoc#132 preload switches all behave
-    exactly as they did until someone sets this.
+    ⚠⚠ **The default is the fix.** v1.132.0 left the user choosing between a
+    probabilistic hang and a cold-start failure, and jdoc#118 stayed open
+    because that choice is not a resolution — it is the defect restated as
+    configuration. An opt-in worker would have been a third switch on the same
+    pile. Defaulting it removes the question instead of adding to it.
+
+    Precedence, explicit before default:
+
+    1. ``JDOCMUNCH_EMBED_WORKER`` set either way wins outright.
+    2. ⚠ ``JDOCMUNCH_PRELOAD_EMBEDDINGS=1`` turns the worker OFF. That user
+       explicitly chose v1.132.0's main-thread import and is entitled to keep
+       getting it; the two mechanisms solve the same problem and running both
+       would import the stack into the process the worker exists to keep clean.
+    3. Otherwise on.
     """
-    return os.environ.get("JDOCMUNCH_EMBED_WORKER", "").strip().lower() in _ENABLED
+    setting = os.environ.get("JDOCMUNCH_EMBED_WORKER", "").strip().lower()
+    if setting in _ENABLED:
+        return True
+    if setting in _DISABLED:
+        return False
+    if os.environ.get("JDOCMUNCH_PRELOAD_EMBEDDINGS", "").strip().lower() in _ENABLED:
+        return False
+    return True
 
 
 def _timeout(var: str, default: float) -> float:
@@ -183,11 +202,20 @@ class WorkerProvider:
         self._next_id = 0
         self._spawns = 0
         self._permanently_failed = False
+        #: The child never started at all — no interpreter at ``sys.executable``,
+        #: a frozen bundle, a sandbox that forbids spawning. ⚠ Distinct from
+        #: every other failure because it is the one case where falling back to
+        #: the in-process import is right: nothing has been learned about the
+        #: import, and the caller would otherwise silently lose semantic search
+        #: on a machine where today it works. See
+        #: ``provider._sentence_transformers_factory``.
+        self.spawn_failed = False
         if spawn:
             try:
                 self._spawn()
-            except Exception as exc:  # pragma: no cover - defensive
+            except Exception as exc:
                 self._permanently_failed = True
+                self.spawn_failed = True
                 self._error = f"{type(exc).__name__}: {exc}"[:300]
                 logger.warning("embedding worker could not be started: %s", self._error)
 
@@ -375,7 +403,20 @@ class WorkerProvider:
                     f"embedding worker died {self._spawns} times "
                     f"({self._error or 'no detail'}); not restarting it again"
                 )
-            self._spawn()
+            try:
+                self._spawn()
+            except Exception as exc:
+                # ⚠ No in-process fallback here, unlike a failure to spawn at
+                # construction. By this point the child HAS run in this session,
+                # so the machine can spawn; something else broke. Importing the
+                # stack into a long-running, multi-threaded server to recover
+                # semantic search would be trading a degraded feature for the
+                # deadlock this module exists to prevent.
+                self._permanently_failed = True
+                self._error = f"{type(exc).__name__}: {exc}"[:300]
+                raise EmbedWorkerError(
+                    f"embedding worker could not be restarted: {self._error}"
+                ) from exc
         if self._ready is None:
             reply = self._await(
                 lambda m: m.get("op") == "ready", ready_timeout(), "startup"

--- a/src/jdocmunch_mcp/embeddings/worker.py
+++ b/src/jdocmunch_mcp/embeddings/worker.py
@@ -1,0 +1,555 @@
+"""Run the sentence-transformers embedder in a child process (jdoc#118).
+
+⚠⚠ **This module exists to resolve a collision, not to be faster.** jdoc#110
+requires that the sentence-transformers import must not delay the MCP
+handshake; jdoc#118 requires that it must not race another thread's native
+loader activity. In one process those cannot both hold — the import is either
+on the main thread (a cold ``torch`` load measured **73.77 s**, past a client's
+30 s connect timeout) or on a background thread (Windows loader lock, observed
+wedged indefinitely by a native stack taken twice 25 s apart). v1.132.0 shipped
+a switch between the two outages because there was no third option *in one
+process*.
+
+A child process is the third option. The import runs concurrently with the live
+server **and** alone in its own loader, so backgrounding becomes safe again.
+
+What crosses the boundary is deliberately one method::
+
+    embed_texts(texts, task_type) -> list[list[float]]
+
+Everything else — provider detection, the HF-cache probe, cache keys, the
+sidecar, identity headers, rotation detection — needs no import and stays in
+the server. ⚠ **numpy stays in the server too**: ``doc_store`` and
+``related_persist`` use it to *score*, and shipping a section matrix down a
+pipe per query would be absurd. Those two sites remain covered by
+:mod:`jdocmunch_mcp.preload`. After this, the server process loads numpy and
+nothing else native; ``torch``/``transformers``/``scipy``/``sklearn`` never
+enter it at all.
+
+⚠ **Phase 1 is opt-in and changes no default.** Set ``JDOCMUNCH_EMBED_WORKER=1``.
+
+Protocol — one JSON object per line, in both directions::
+
+    -> {"op": "ready"}
+    <- {"op": "ready", "ok": true, "dim": 384, "stdout_private": true}
+    -> {"op": "embed", "id": 7, "texts": [...], "task": "retrieval_document"}
+    <- {"id": 7, "ok": true, "dim": 384, "vecs": "<base64 little-endian float32>"}
+    -> {"op": "shutdown"}
+
+⚠ Vectors are base64 float32, not JSON floats. A 5,300-section corpus at 384
+dims is ~30 MB as JSON text and ~8 MB as bytes, and the child was already
+paying a ``.tolist()`` conversion that this replaces rather than adds.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import queue
+import subprocess
+import sys
+import threading
+from array import array
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_ENABLED = ("1", "true", "yes", "on")
+
+#: Texts per request. Bounds both the child's peak memory and, more
+#: importantly, the per-request timeout: ``embed_sections`` hands over every
+#: cache miss in ONE call, so an unchunked request on a full corpus has no
+#: timeout that is both generous enough to succeed and tight enough to mean
+#: anything.
+CHUNK_SIZE = 256
+
+#: Seconds to wait for the child to finish importing and load the model. Sized
+#: off the measured cold-import figure in jdoc#118 (73.77 s) with headroom: the
+#: whole point is that this wait is BOUNDED, not that it is short.
+READY_TIMEOUT_DEFAULT = 300.0
+
+#: Seconds to wait for one chunk of ``CHUNK_SIZE`` texts.
+REQUEST_TIMEOUT_DEFAULT = 120.0
+
+
+class EmbedWorkerError(RuntimeError):
+    """The embedding worker could not answer.
+
+    ⚠ Raised rather than returning empty vectors, deliberately. ``embed_sections``
+    reads an exception as ``embed_failed`` and preserves the existing sidecar;
+    a list of empty vectors reads as "this corpus legitimately has none", which
+    is the jdoc#107 / jdoc#109 data-loss shape.
+    """
+
+
+def worker_enabled() -> bool:
+    """Whether sentence-transformers should run out of process.
+
+    Off unless explicitly on. Phase 1 changes no default: the in-process
+    provider, the jdoc#118 probe and the jdoc#132 preload switches all behave
+    exactly as they did until someone sets this.
+    """
+    return os.environ.get("JDOCMUNCH_EMBED_WORKER", "").strip().lower() in _ENABLED
+
+
+def _timeout(var: str, default: float) -> float:
+    """Read a positive float from ``var``, falling back to ``default``.
+
+    A garbage value falls back rather than raising: this is read on the embed
+    path, and failing an index over a typo'd env var is worse than using the
+    documented default.
+    """
+    raw = os.environ.get(var, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def ready_timeout() -> float:
+    return _timeout("JDOCMUNCH_EMBED_WORKER_READY_TIMEOUT", READY_TIMEOUT_DEFAULT)
+
+
+def request_timeout() -> float:
+    return _timeout("JDOCMUNCH_EMBED_WORKER_TIMEOUT", REQUEST_TIMEOUT_DEFAULT)
+
+
+# ---------------------------------------------------------------------------
+# Wire format
+# ---------------------------------------------------------------------------
+
+def encode_vectors(rows: list) -> tuple[str, int]:
+    """Pack ``rows`` (equal-length float lists) into base64 little-endian float32."""
+    if not rows:
+        return "", 0
+    dim = len(rows[0])
+    flat = array("f")
+    for row in rows:
+        if len(row) != dim:
+            raise ValueError(f"ragged embedding rows: {len(row)} != {dim}")
+        flat.extend(row)
+    if sys.byteorder != "little":
+        flat.byteswap()
+    return base64.b64encode(flat.tobytes()).decode("ascii"), dim
+
+
+def decode_vectors(payload: str, dim: int) -> list:
+    """Unpack :func:`encode_vectors` output back into a list of float lists."""
+    if not payload or dim <= 0:
+        return []
+    flat = array("f")
+    flat.frombytes(base64.b64decode(payload))
+    if sys.byteorder != "little":
+        flat.byteswap()
+    values = flat.tolist()
+    return [values[i:i + dim] for i in range(0, len(values), dim)]
+
+
+# ---------------------------------------------------------------------------
+# Parent side
+# ---------------------------------------------------------------------------
+
+class WorkerProvider:
+    """Parent-side stand-in for ``_SentenceTransformersProvider``.
+
+    Interface-compatible with the in-process providers: ``embed_texts`` is the
+    only method the rest of the codebase calls.
+
+    ⚠ Construction **spawns but does not wait**. The whole gain would be lost
+    if building the provider blocked on the child's import — that is jdoc#110's
+    slow handshake wearing a different hat. The wait happens in ``embed_texts``,
+    bounded, on whatever thread actually needs a vector.
+    """
+
+    #: One respawn, then the provider is done for this session. A child that
+    #: dies twice is a broken install, and an unbounded respawn loop would turn
+    #: that into a fork bomb on the embed path.
+    MAX_SPAWNS = 2
+
+    def __init__(self, model_name: str, *, command: Optional[list] = None, spawn: bool = True):
+        self._model_name = model_name
+        self._command = command
+        self._lock = threading.RLock()
+        self._proc: Optional[subprocess.Popen] = None
+        self._replies: "queue.Queue" = queue.Queue()
+        self._ready: Optional[bool] = None
+        self._error = ""
+        self._dim: Optional[int] = None
+        self._next_id = 0
+        self._spawns = 0
+        self._permanently_failed = False
+        if spawn:
+            try:
+                self._spawn()
+            except Exception as exc:  # pragma: no cover - defensive
+                self._permanently_failed = True
+                self._error = f"{type(exc).__name__}: {exc}"[:300]
+                logger.warning("embedding worker could not be started: %s", self._error)
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def _build_command(self) -> list:
+        if self._command is not None:
+            return list(self._command)
+        return [
+            sys.executable,
+            "-m", "jdocmunch_mcp.embeddings.worker",
+            "--model", self._model_name,
+        ]
+
+    def _spawn(self) -> None:
+        env = dict(os.environ)
+        # Only set what is unset: a user who configured these owns them. The
+        # child's stdout carries the protocol, so a progress bar written there
+        # would be a parse error rather than cosmetic noise — the child also
+        # swaps fd 1 to stderr for exactly this reason, and this is the cheap
+        # belt to that braces.
+        env.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+        env.setdefault("TQDM_DISABLE", "1")
+
+        kwargs: dict = {}
+        if sys.platform == "win32":
+            # No console flash when the server itself runs windowless.
+            kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+        self._spawns += 1
+        # ⚠ Orphan prevention rides on the stdin pipe rather than on a job
+        # object: when this process dies, however it dies, the write end closes,
+        # the child's `for raw in sys.stdin.buffer` sees EOF and it exits. An
+        # orphaned torch process is a support ticket, so the mechanism should be
+        # the one that survives a hard kill of the parent.
+        #
+        # ⚠ It is not instant, and the comment should not pretend otherwise: the
+        # child notices at its next read, so one killed mid-import lingers until
+        # that import returns. It cannot linger forever only because the child's
+        # import is the single-threaded one that does not wedge — which is the
+        # premise of this whole module, so if that premise is ever wrong this is
+        # one of the places it shows up.
+        #
+        # ⚠ stderr is INHERITED on purpose: the child's chatter belongs in the
+        # server's log stream. Capturing it into a pipe nobody drains would
+        # deadlock the child on a full buffer, which is a fine way to
+        # reintroduce a hang while fixing one.
+        self._proc = subprocess.Popen(
+            self._build_command(),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=None,
+            env=env,
+            **kwargs,
+        )
+        self._replies = queue.Queue()
+        self._ready = None
+        self._dim = None
+        reader = threading.Thread(
+            target=self._read_replies,
+            args=(self._proc, self._replies),
+            name="jdocmunch-embed-worker-reader",
+            daemon=True,
+        )
+        reader.start()
+        self._send({"op": "ready", "model": self._model_name})
+
+    @staticmethod
+    def _read_replies(proc: subprocess.Popen, replies: "queue.Queue") -> None:
+        """Drain the child's stdout onto a queue; enqueue None at EOF.
+
+        A reader thread rather than a poll loop because ``select`` does not
+        work on pipes on Windows, which is the platform this whole issue is
+        about.
+        """
+        try:
+            stream = proc.stdout
+            if stream is None:  # pragma: no cover - defensive
+                return
+            for raw in stream:
+                line = raw.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    replies.put(json.loads(line))
+                except ValueError:
+                    logger.debug("embedding worker sent an unparseable line: %.200s", line)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("embedding worker reader stopped: %s", exc)
+        finally:
+            replies.put(None)
+
+    def _send(self, message: dict) -> None:
+        proc = self._proc
+        if proc is None or proc.stdin is None:
+            raise EmbedWorkerError("embedding worker is not running")
+        payload = (json.dumps(message, ensure_ascii=False) + "\n").encode("utf-8")
+        try:
+            proc.stdin.write(payload)
+            proc.stdin.flush()
+        except (BrokenPipeError, OSError, ValueError) as exc:
+            raise EmbedWorkerError(f"embedding worker stdin is closed: {exc}") from exc
+
+    def _await(self, predicate, timeout: float, what: str) -> dict:
+        """Wait for a reply satisfying ``predicate``; kill the child on timeout.
+
+        Replies that do not match are dropped rather than requeued: requests are
+        serialised under ``self._lock``, so a non-matching reply is a stale
+        answer to a request that already timed out and nothing will ever want it.
+        """
+        import time as _time
+
+        deadline = _time.monotonic() + timeout
+        while True:
+            remaining = deadline - _time.monotonic()
+            if remaining <= 0:
+                self._kill(f"{what} timed out after {timeout:.0f}s")
+                raise EmbedWorkerError(
+                    f"embedding worker {what} timed out after {timeout:.0f}s "
+                    "(the worker was killed; lexical search is unaffected)"
+                )
+            try:
+                reply = self._replies.get(timeout=min(remaining, 1.0))
+            except queue.Empty:
+                continue
+            if reply is None:
+                self._kill(f"the worker exited during {what}")
+                raise EmbedWorkerError(f"embedding worker exited during {what}")
+            if predicate(reply):
+                return reply
+
+    def _kill(self, reason: str) -> None:
+        """Terminate the child. ⚠ This is the property a thread cannot offer.
+
+        A wedged thread inside ``LdrLoadDll`` is a kernel-mode wait: a timeout,
+        a thread kill and a try/except are all equally useless against it. A
+        wedged *process* is killable, and that is what turns this design from a
+        relocation of jdoc#118 into a fix for it.
+        """
+        proc, self._proc = self._proc, None
+        self._ready = False
+        self._error = reason
+        if proc is None:
+            return
+        logger.warning("killing the embedding worker: %s", reason)
+        for step in (proc.terminate, proc.kill):
+            try:
+                step()
+                proc.wait(timeout=5)
+                return
+            except Exception:
+                continue
+
+    def close(self) -> None:
+        """Ask the child to exit, then make sure it did."""
+        with self._lock:
+            proc = self._proc
+            if proc is None:
+                return
+            try:
+                self._send({"op": "shutdown"})
+                proc.wait(timeout=5)
+                self._proc = None
+                return
+            except Exception:
+                pass
+            self._kill("shutdown requested")
+
+    def _ensure_ready(self) -> None:
+        if self._permanently_failed:
+            raise EmbedWorkerError(self._error or "embedding worker is unavailable")
+        if self._ready:
+            if self._proc is not None and self._proc.poll() is None:
+                return
+            # Was ready, has since died — respawn once and re-handshake.
+            # ⚠ Drop the dead handle here. Leaving it in place sends the next
+            # handshake down a closed pipe and burns one of MAX_SPAWNS on a
+            # failure we already knew about.
+            self._proc = None
+            self._ready = None
+        if self._proc is None:
+            if self._spawns >= self.MAX_SPAWNS:
+                self._permanently_failed = True
+                raise EmbedWorkerError(
+                    f"embedding worker died {self._spawns} times "
+                    f"({self._error or 'no detail'}); not restarting it again"
+                )
+            self._spawn()
+        if self._ready is None:
+            reply = self._await(
+                lambda m: m.get("op") == "ready", ready_timeout(), "startup"
+            )
+            if not reply.get("ok"):
+                # ⚠ An import that RAISES is a broken install, not a race.
+                # Respawning would fail identically and cost another cold
+                # import, so this is terminal for the session.
+                self._permanently_failed = True
+                self._ready = False
+                self._error = str(reply.get("error") or "unknown")[:300]
+                raise EmbedWorkerError(
+                    f"embedding worker could not load the model: {self._error}"
+                )
+            self._ready = True
+            self._dim = reply.get("dim") or None
+            if reply.get("stdout_private") is False:
+                logger.warning(
+                    "the embedding worker could not give itself a private stdout; "
+                    "library chatter may corrupt its protocol stream"
+                )
+            logger.info(
+                "embedding worker ready (model=%s, dim=%s)", self._model_name, self._dim
+            )
+        if not self._ready:
+            raise EmbedWorkerError(self._error or "embedding worker is unavailable")
+
+    # -- the one method that crosses the boundary --------------------------
+
+    def embed_texts(self, texts: list, task_type: str = "retrieval_document") -> list:
+        if not texts:
+            return []
+        out: list = []
+        for start in range(0, len(texts), CHUNK_SIZE):
+            out.extend(self._embed_chunk(texts[start:start + CHUNK_SIZE], task_type))
+        return out
+
+    def _embed_chunk(self, texts: list, task_type: str) -> list:
+        with self._lock:
+            self._ensure_ready()
+            self._next_id += 1
+            request_id = self._next_id
+            self._send({
+                "op": "embed", "id": request_id, "texts": texts, "task": task_type,
+            })
+            reply = self._await(
+                lambda m: m.get("id") == request_id, request_timeout(), "an embed request"
+            )
+            if not reply.get("ok"):
+                raise EmbedWorkerError(
+                    f"embedding worker failed: {str(reply.get('error') or 'unknown')[:300]}"
+                )
+            vectors = decode_vectors(reply.get("vecs") or "", int(reply.get("dim") or 0))
+            if len(vectors) != len(texts):
+                raise EmbedWorkerError(
+                    f"embedding worker returned {len(vectors)} vectors for {len(texts)} texts"
+                )
+            return vectors
+
+
+# ---------------------------------------------------------------------------
+# Child side
+# ---------------------------------------------------------------------------
+
+def _child_send(out, message: dict) -> bool:
+    try:
+        out.write((json.dumps(message, ensure_ascii=False) + "\n").encode("utf-8"))
+        out.flush()
+        return True
+    except Exception:
+        return False
+
+
+def _child_main(argv: Optional[list] = None) -> int:
+    """Entry point for ``python -m jdocmunch_mcp.embeddings.worker``.
+
+    ⚠ The import of sentence-transformers happens HERE, on the only thread in
+    a process that does nothing else. That is the entire design.
+    """
+    argv = list(sys.argv[1:] if argv is None else argv)
+    model_name = ""
+    if "--model" in argv:
+        index = argv.index("--model")
+        if index + 1 < len(argv):
+            model_name = argv[index + 1]
+
+    # Same reasoning as jdoc#110's transport guard, applied to this protocol:
+    # the child's stdout carries framed JSON, and a C extension writing to
+    # fd 1 would corrupt it in a way `redirect_stdout` cannot prevent.
+    try:
+        from jdocmunch_mcp.stdio_guard import claim_stdout
+        stream, swapped = claim_stdout()
+    except Exception:  # pragma: no cover - defensive
+        stream, swapped = None, False
+    out = stream.buffer if stream is not None else sys.stdout.buffer
+
+    model = None
+    for raw in sys.stdin.buffer:
+        line = raw.decode("utf-8", errors="replace").strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except ValueError:
+            continue
+        op = message.get("op")
+
+        if op == "shutdown":
+            return 0
+
+        if op == "ready":
+            requested = message.get("model") or model_name
+            ok, error, dim = True, "", None
+            try:
+                model, dim = _load_model(requested)
+            except BaseException as exc:
+                # ⚠ BaseException: a broken native dependency can raise things
+                # Exception does not cover, and the parent must get an answer
+                # either way — a child that dies silently looks exactly like
+                # the hang this replaces.
+                ok, error = False, f"{type(exc).__name__}: {exc}"[:300]
+            if not _child_send(out, {
+                "op": "ready", "ok": ok, "error": error,
+                "dim": dim, "stdout_private": swapped,
+            }):
+                return 1
+            continue
+
+        if op == "embed":
+            request_id = message.get("id")
+            texts = message.get("texts") or []
+            if model is None:
+                _child_send(out, {
+                    "id": request_id, "ok": False, "error": "model is not loaded",
+                })
+                continue
+            try:
+                rows = _encode_texts(model, texts)
+                payload, dim = encode_vectors(rows)
+                sent = _child_send(out, {
+                    "id": request_id, "ok": True, "dim": dim, "vecs": payload,
+                })
+            except BaseException as exc:
+                sent = _child_send(out, {
+                    "id": request_id, "ok": False,
+                    "error": f"{type(exc).__name__}: {exc}"[:300],
+                })
+            if not sent:
+                return 1
+            continue
+
+    return 0
+
+
+def _load_model(model_name: str):
+    """Import sentence-transformers and load ``model_name``. Returns (model, dim)."""
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer(model_name)
+    dim = None
+    try:
+        dim = int(model.get_sentence_embedding_dimension())
+    except Exception:
+        dim = None
+    return model, dim
+
+
+def _encode_texts(model, texts: list) -> list:
+    """Encode ``texts`` to a list of equal-length float lists."""
+    if not texts:
+        return []
+    encoded = model.encode(texts, batch_size=64, show_progress_bar=False)
+    return [list(map(float, row)) for row in encoded]
+
+
+if __name__ == "__main__":  # pragma: no cover - process entry point
+    sys.exit(_child_main())

--- a/src/jdocmunch_mcp/preload.py
+++ b/src/jdocmunch_mcp/preload.py
@@ -263,6 +263,13 @@ def preload_embedding_stack() -> dict:
     from jdocmunch_mcp.embeddings import provider as prov
 
     try:
+        # ⚠⚠ jdoc#118 phase 1: the worker exists so this process NEVER imports
+        # the stack. Preloading it here anyway would import it into the very
+        # process the worker is keeping clean — paying the slow handshake the
+        # opt-in exists to trade for, and getting nothing back for it.
+        from jdocmunch_mcp.embeddings import worker as _worker
+        if _worker.worker_enabled():
+            return {"sentence_transformers": "absent: embedding worker owns the import"}
         if prov.get_provider_name() != "sentence-transformers":
             return {"sentence_transformers": "absent: provider not selected"}
         if not prov._st_model_is_cached(prov._st_model_name()):

--- a/tests/test_jdoc_118_embed_worker.py
+++ b/tests/test_jdoc_118_embed_worker.py
@@ -1,0 +1,449 @@
+"""jdoc#118 phase 1 — sentence-transformers in a child process.
+
+⚠ These go through REAL subprocesses. The whole mechanism is "the import
+happens in another process", and an in-process test of that tests the mock
+(the jdoc#129 lesson, which was learned on the fd swap and applies verbatim
+here).
+
+The protocol tests drive a *fake* child written to ``tmp_path``: it speaks the
+same wire format with no sentence-transformers anywhere, so they run on a
+machine with no embedding stack, with a broken one, or on CI. The real child
+module is exercised separately, on the path that does not need a working model.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from jdocmunch_mcp.embeddings import provider as prov
+from jdocmunch_mcp.embeddings import worker as w
+
+
+# ---------------------------------------------------------------------------
+# Fake children
+# ---------------------------------------------------------------------------
+
+_FAKE_CHILD = '''
+import json, sys
+
+def send(msg):
+    sys.stdout.write(json.dumps(msg) + "\\n")
+    sys.stdout.flush()
+
+MODE = {mode!r}
+DIM = 4
+ready_seen = 0
+
+for raw in sys.stdin:
+    line = raw.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    op = msg.get("op")
+    if op == "shutdown":
+        sys.exit(0)
+    if op == "ready":
+        ready_seen += 1
+        if MODE == "die_on_ready":
+            sys.exit(3)
+        if MODE == "silent":
+            # Never answer. The parent must bound this itself.
+            for _ in sys.stdin:
+                pass
+            sys.exit(0)
+        if MODE == "broken_model":
+            send({{"op": "ready", "ok": False, "error": "ImportError: no HybridCache"}})
+            continue
+        send({{"op": "ready", "ok": True, "error": "", "dim": DIM, "stdout_private": True}})
+        continue
+    if op == "embed":
+        texts = msg.get("texts") or []
+        if MODE == "short_answer":
+            rows = texts[:-1]
+        else:
+            rows = texts
+        vecs = [[float(len(t)), float(sum(t.encode("utf-8")) % 97), 0.25, -1.5] for t in rows]
+        payload, dim = ("", 0)
+        if vecs:
+            import base64
+            from array import array
+            flat = array("f")
+            for row in vecs:
+                flat.extend(row)
+            if sys.byteorder != "little":
+                flat.byteswap()
+            payload, dim = base64.b64encode(flat.tobytes()).decode("ascii"), DIM
+        send({{"id": msg.get("id"), "ok": True, "dim": dim, "vecs": payload}})
+        continue
+'''
+
+
+def _fake_child(tmp_path, mode="ok"):
+    path = tmp_path / f"fake_child_{mode}.py"
+    path.write_text(_FAKE_CHILD.format(mode=mode), encoding="utf-8")
+    return [sys.executable, str(path)]
+
+
+def _expected(text):
+    return [float(len(text)), float(sum(text.encode("utf-8")) % 97), 0.25, -1.5]
+
+
+@pytest.fixture
+def fake_worker(tmp_path):
+    """Build a WorkerProvider against a fake child; always tear the child down."""
+    built = []
+
+    def _build(mode="ok", **kwargs):
+        provider = w.WorkerProvider("fake-model", command=_fake_child(tmp_path, mode), **kwargs)
+        built.append(provider)
+        return provider
+
+    yield _build
+    for provider in built:
+        provider.close()
+
+
+# ---------------------------------------------------------------------------
+# Wire format
+# ---------------------------------------------------------------------------
+
+class TestWireFormat:
+    def test_roundtrip_preserves_values_and_shape(self):
+        rows = [[0.5, -1.5, 2.25], [1.0, 0.0, -0.125]]
+        payload, dim = w.encode_vectors(rows)
+        assert dim == 3
+        assert w.decode_vectors(payload, dim) == rows
+
+    def test_empty_rows_encode_to_nothing_and_decode_back(self):
+        payload, dim = w.encode_vectors([])
+        assert (payload, dim) == ("", 0)
+        assert w.decode_vectors("", 0) == []
+
+    def test_ragged_rows_raise_rather_than_silently_truncating(self):
+        # jdoc#109: a width mismatch that returns a plausible number is worse
+        # than one that raises. cosine_similarity's zip() truncated a 768-dim
+        # query against a 384-dim vector and returned a confident 0.707.
+        with pytest.raises(ValueError):
+            w.encode_vectors([[1.0, 2.0], [3.0]])
+
+    def test_base64_is_smaller_than_json_floats(self):
+        # The reason the format is not JSON floats: a 5,300-section corpus at
+        # 384 dims is ~30 MB as text.
+        rows = [[0.123456789] * 384 for _ in range(64)]
+        payload, _ = w.encode_vectors(rows)
+        assert len(payload) < len(json.dumps(rows)) / 2
+
+
+# ---------------------------------------------------------------------------
+# Enablement — phase 1 changes no default
+# ---------------------------------------------------------------------------
+
+class TestEnablement:
+    def test_off_when_unset(self, monkeypatch):
+        monkeypatch.delenv("JDOCMUNCH_EMBED_WORKER", raising=False)
+        assert w.worker_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", " yes ", "on"])
+    def test_on_for_affirmative_values(self, monkeypatch, value):
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", value)
+        assert w.worker_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "maybe"])
+    def test_off_for_everything_else(self, monkeypatch, value):
+        # ⚠ Asymmetric on purpose: a typo must not silently enable a new
+        # process, the same reasoning preload_enabled() uses in the other
+        # direction.
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", value)
+        assert w.worker_enabled() is False
+
+    def test_garbage_timeout_falls_back_to_the_default(self, monkeypatch):
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER_TIMEOUT", "soon")
+        assert w.request_timeout() == w.REQUEST_TIMEOUT_DEFAULT
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER_TIMEOUT", "-4")
+        assert w.request_timeout() == w.REQUEST_TIMEOUT_DEFAULT
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER_TIMEOUT", "12.5")
+        assert w.request_timeout() == 12.5
+
+
+# ---------------------------------------------------------------------------
+# Real subprocess round trips
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+    def test_vectors_come_back_through_a_real_pipe(self, fake_worker):
+        provider = fake_worker()
+        texts = ["alpha", "beta gamma", "d"]
+        vectors = provider.embed_texts(texts)
+        assert vectors == [_expected(t) for t in texts]
+
+    def test_no_texts_never_spawns_a_request(self, fake_worker):
+        provider = fake_worker()
+        assert provider.embed_texts([]) == []
+
+    def test_a_corpus_larger_than_one_chunk_returns_in_order(self, fake_worker):
+        # embed_sections hands over EVERY cache miss in one call, so chunking
+        # is what makes the per-request timeout mean anything.
+        provider = fake_worker()
+        texts = [f"section-{i}" for i in range(w.CHUNK_SIZE * 2 + 5)]
+        vectors = provider.embed_texts(texts)
+        assert len(vectors) == len(texts)
+        assert vectors == [_expected(t) for t in texts]
+
+    def test_construction_does_not_wait_for_the_child(self, fake_worker):
+        # ⚠ The whole gain is lost if building the provider blocks on the
+        # import — that is jdoc#110's slow handshake in a different hat.
+        provider = fake_worker("silent")
+        assert provider._ready is None
+
+    def test_close_stops_the_child(self, fake_worker):
+        provider = fake_worker()
+        provider.embed_texts(["x"])
+        proc = provider._proc
+        provider.close()
+        assert proc.poll() is not None
+
+
+# ---------------------------------------------------------------------------
+# Failure handling — the killable property is the point
+# ---------------------------------------------------------------------------
+
+class TestFailures:
+    def test_a_silent_child_is_bounded_and_then_killed(self, fake_worker, monkeypatch):
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER_READY_TIMEOUT", "2")
+        provider = fake_worker("silent")
+        with pytest.raises(w.EmbedWorkerError) as excinfo:
+            provider.embed_texts(["anything"])
+        assert "timed out" in str(excinfo.value)
+        # ⚠⚠ This is the assertion that separates a fix from a relocation. A
+        # thread wedged in LdrLoadDll is a kernel-mode wait that no timeout,
+        # thread kill or try/except can touch. A process can just be killed.
+        assert provider._proc is None
+
+    def test_a_timeout_raises_rather_than_returning_empty_vectors(self, fake_worker, monkeypatch):
+        # embed_sections reads an exception as embed_failed and PRESERVES the
+        # sidecar; a list of empty vectors reads as "this corpus has none",
+        # which is the jdoc#107/#109 data-loss shape.
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER_READY_TIMEOUT", "2")
+        provider = fake_worker("silent")
+        with pytest.raises(w.EmbedWorkerError):
+            provider.embed_texts(["anything"])
+
+    def test_a_model_that_cannot_load_is_terminal_not_retried(self, fake_worker):
+        # An import that RAISES is a broken install, not a race. Respawning
+        # would fail identically and cost another cold import.
+        provider = fake_worker("broken_model")
+        with pytest.raises(w.EmbedWorkerError) as first:
+            provider.embed_texts(["x"])
+        assert "HybridCache" in str(first.value)
+        spawns = provider._spawns
+        with pytest.raises(w.EmbedWorkerError):
+            provider.embed_texts(["x"])
+        assert provider._spawns == spawns, "a broken model must not be respawned"
+
+    def test_a_dying_child_is_respawned_once_and_then_given_up_on(self, fake_worker):
+        provider = fake_worker("die_on_ready")
+        for _ in range(w.WorkerProvider.MAX_SPAWNS):
+            with pytest.raises(w.EmbedWorkerError):
+                provider.embed_texts(["x"])
+        assert provider._spawns == w.WorkerProvider.MAX_SPAWNS
+        with pytest.raises(w.EmbedWorkerError) as final:
+            provider.embed_texts(["x"])
+        assert "not restarting" in str(final.value)
+        assert provider._spawns == w.WorkerProvider.MAX_SPAWNS
+
+    def test_a_short_answer_is_refused_rather_than_zipped_away(self, fake_worker):
+        # embed_sections zips sections against the returned vectors, so a
+        # short reply would silently shift every vector onto the wrong section.
+        provider = fake_worker("short_answer")
+        with pytest.raises(w.EmbedWorkerError) as excinfo:
+            provider.embed_texts(["a", "bb", "ccc"])
+        assert "2 vectors for 3 texts" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# The real child module
+# ---------------------------------------------------------------------------
+
+class TestRealChild:
+    def test_it_reports_a_load_failure_instead_of_dying_silently(self):
+        # Runs anywhere: the model name cannot resolve, and with no
+        # sentence-transformers installed the import raises first. Either way
+        # the parent must get an answer — a child that dies quietly looks
+        # exactly like the hang this design replaces.
+        proc = subprocess.run(
+            [sys.executable, "-m", "jdocmunch_mcp.embeddings.worker",
+             "--model", "jdoc118-definitely-not-a-real-model"],
+            input=json.dumps({"op": "ready"}) + "\n",
+            capture_output=True, text=True, timeout=300,
+            encoding="utf-8", errors="replace",
+        )
+        lines = [ln for ln in (proc.stdout or "").splitlines() if ln.strip()]
+        assert lines, f"the child said nothing (stderr: {proc.stderr[-500:]})"
+        reply = json.loads(lines[-1])
+        assert reply["op"] == "ready"
+        assert reply["ok"] is False
+        assert reply["error"]
+
+    def test_it_exits_cleanly_on_shutdown(self):
+        proc = subprocess.run(
+            [sys.executable, "-m", "jdocmunch_mcp.embeddings.worker"],
+            input=json.dumps({"op": "shutdown"}) + "\n",
+            capture_output=True, text=True, timeout=60,
+            encoding="utf-8", errors="replace",
+        )
+        assert proc.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# ⚠⚠ The mechanism guard — see the design's §6
+# ---------------------------------------------------------------------------
+
+_MODULES_PROBE = textwrap.dedent(
+    """
+    import json, sys
+    from jdocmunch_mcp.embeddings import worker as w
+
+    provider = w.WorkerProvider("fake-model", command=[sys.executable, sys.argv[1]])
+    vectors = provider.embed_texts(["alpha", "beta"])
+    provider.close()
+
+    print(json.dumps({
+        "vectors": len(vectors),
+        "loaded": sorted(
+            m for m in ("sentence_transformers", "transformers", "torch", "scipy", "sklearn")
+            if m in sys.modules
+        ),
+    }))
+    """
+)
+
+
+def test_the_server_process_never_imports_the_embedding_stack(tmp_path):
+    """The property that closes jdoc#118 without reproducing the race.
+
+    ⚠⚠ There is no A/B for this bug: the wedge stopped reproducing in BOTH
+    arms after ~30 server starts, and the machine will not go cold on demand.
+    This asserts something stronger and deterministic instead — the deadlock is
+    *unreachable*, because the process that used to wedge no longer loads any
+    of the libraries that wedge it. Reachability beats "it did not happen this
+    time".
+    """
+    probe = tmp_path / "modules_probe.py"
+    probe.write_text(_MODULES_PROBE, encoding="utf-8")
+    child = _fake_child(tmp_path, "ok")[1]
+
+    proc = subprocess.run(
+        [sys.executable, str(probe), child],
+        capture_output=True, text=True, timeout=120,
+        encoding="utf-8", errors="replace",
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    result = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert result["vectors"] == 2, "the probe must actually embed, or it proves nothing"
+    assert result["loaded"] == [], (
+        "the parent process imported the embedding stack: "
+        f"{result['loaded']} — jdoc#118's deadlock is reachable again"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wiring into provider selection
+# ---------------------------------------------------------------------------
+
+class TestProviderWiring:
+    @pytest.fixture(autouse=True)
+    def _clean(self, monkeypatch):
+        prov._reset_provider_cache()
+        monkeypatch.setenv("JDOCMUNCH_EMBEDDING_PROVIDER", "sentence-transformers")
+        yield
+        prov._reset_provider_cache()
+
+    def test_the_in_process_provider_is_still_the_default(self, monkeypatch):
+        monkeypatch.delenv("JDOCMUNCH_EMBED_WORKER", raising=False)
+        sentinel = object()
+        monkeypatch.setattr(prov, "_SentenceTransformersProvider", lambda: sentinel)
+        assert prov._sentence_transformers_factory() is sentinel
+
+    def test_the_worker_is_used_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", "1")
+        seen = {}
+
+        class _Stub:
+            def __init__(self, model_name):
+                seen["model"] = model_name
+
+        monkeypatch.setattr(w, "WorkerProvider", _Stub)
+        monkeypatch.setenv("JDOCMUNCH_ST_MODEL", "some-model")
+        assert isinstance(prov._sentence_transformers_factory(), _Stub)
+        assert seen["model"] == "some-model"
+
+    def test_the_import_probe_is_skipped_when_the_worker_owns_the_import(self, monkeypatch):
+        # The probe protects THIS process from an import it no longer performs.
+        # Running it anyway is a subprocess of pure cost.
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", "1")
+        called = []
+        monkeypatch.setattr(
+            prov, "_sentence_transformers_imports_cleanly",
+            lambda: called.append(True) or True,
+        )
+        sentinel = object()
+        monkeypatch.setitem(prov._PROVIDER_FACTORIES, "sentence-transformers", lambda: sentinel)
+        assert prov._get_provider() is sentinel
+        assert called == []
+
+    def test_the_import_probe_still_runs_without_the_worker(self, monkeypatch):
+        monkeypatch.delenv("JDOCMUNCH_EMBED_WORKER", raising=False)
+        called = []
+        monkeypatch.setattr(
+            prov, "_sentence_transformers_imports_cleanly",
+            lambda: called.append(True) or True,
+        )
+        sentinel = object()
+        monkeypatch.setitem(prov._PROVIDER_FACTORIES, "sentence-transformers", lambda: sentinel)
+        assert prov._get_provider() is sentinel
+        assert called == [True]
+
+    def test_warmup_skips_the_probe_when_the_worker_owns_the_import(self, monkeypatch):
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", "1")
+        monkeypatch.delenv("JDOCMUNCH_EMBED_WARMUP", raising=False)
+        called = []
+        monkeypatch.setattr(
+            prov, "_sentence_transformers_imports_cleanly",
+            lambda: called.append(True) or False,
+        )
+        monkeypatch.setattr(prov, "_st_model_is_cached", lambda _model: True)
+        monkeypatch.setattr(prov, "embed_query", lambda _q: [0.0])
+        assert prov.warmup() == "sentence-transformers"
+        assert called == []
+
+    def test_the_preload_declines_when_the_worker_owns_the_import(self, monkeypatch):
+        # ⚠⚠ Preloading here would import the stack into the very process the
+        # worker keeps clean — paying the slow handshake and getting nothing.
+        from jdocmunch_mcp import preload
+
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", "1")
+        monkeypatch.setenv("JDOCMUNCH_PRELOAD_EMBEDDINGS", "1")
+        report = preload.preload_embedding_stack()
+        assert report == {"sentence_transformers": "absent: embedding worker owns the import"}
+
+
+def test_the_identity_header_does_not_change_when_the_worker_is_enabled(monkeypatch):
+    """⚠⚠ Flipping dim from None to 384 would re-embed every existing corpus.
+
+    ``_provider_identity`` returns None for sentence-transformers and the cache
+    treats that as a wildcard. Filling it in from what the child reports would
+    make ``identity_matches`` fail on every sidecar written before this change
+    — jdoc#109's escalation, triggered by a refactor rather than a rotation.
+    """
+    monkeypatch.setenv("JDOCMUNCH_ST_MODEL", "all-MiniLM-L6-v2")
+    monkeypatch.delenv("JDOCMUNCH_EMBED_WORKER", raising=False)
+    without = prov._provider_identity("sentence-transformers")
+    signature_without = prov._provider_signature("sentence-transformers")
+    monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", "1")
+    assert prov._provider_identity("sentence-transformers") == without
+    assert prov._provider_signature("sentence-transformers") == signature_without
+    assert without[1] is None

--- a/tests/test_jdoc_118_embed_worker.py
+++ b/tests/test_jdoc_118_embed_worker.py
@@ -222,6 +222,31 @@ class TestRoundTrip:
         provider = fake_worker("silent")
         assert provider._ready is None
 
+    def test_a_process_that_never_calls_close_still_exits_clean(self, tmp_path):
+        """atexit must reap the child, and the pipes must be closed.
+
+        ⚠ Not a tidiness point. The PostToolUse reindex hook is a whole process
+        per edited file, so "the caller forgot to close" is the common case,
+        not the exceptional one. `-W error::ResourceWarning` turns an unclosed
+        pipe into a non-zero exit.
+        """
+        script = tmp_path / "no_close.py"
+        script.write_text(
+            "import sys\n"
+            "from jdocmunch_mcp.embeddings import worker as w\n"
+            "p = w.WorkerProvider('fake-model', command=[sys.executable, sys.argv[1]])\n"
+            "assert len(p.embed_texts(['x'])) == 1\n",
+            encoding="utf-8",
+        )
+        proc = subprocess.run(
+            [sys.executable, "-W", "error::ResourceWarning", str(script),
+             _fake_child(tmp_path, "ok")[1]],
+            capture_output=True, text=True, timeout=120,
+            encoding="utf-8", errors="replace",
+        )
+        assert proc.returncode == 0, proc.stderr[-1500:]
+        assert "ResourceWarning" not in proc.stderr
+
     def test_close_stops_the_child(self, fake_worker):
         provider = fake_worker()
         provider.embed_texts(["x"])

--- a/tests/test_jdoc_118_embed_worker.py
+++ b/tests/test_jdoc_118_embed_worker.py
@@ -143,22 +143,45 @@ class TestWireFormat:
 # ---------------------------------------------------------------------------
 
 class TestEnablement:
-    def test_off_when_unset(self, monkeypatch):
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
         monkeypatch.delenv("JDOCMUNCH_EMBED_WORKER", raising=False)
-        assert w.worker_enabled() is False
+        monkeypatch.delenv("JDOCMUNCH_PRELOAD_EMBEDDINGS", raising=False)
+
+    def test_on_when_unset(self):
+        # ⚠⚠ The default IS the fix. v1.132.0 left the user choosing between a
+        # probabilistic hang and a cold-start failure, and #118 stayed open
+        # because that choice is the defect restated as configuration. An
+        # opt-in worker would have been a third switch on the same pile.
+        assert w.worker_enabled() is True
 
     @pytest.mark.parametrize("value", ["1", "true", "TRUE", " yes ", "on"])
     def test_on_for_affirmative_values(self, monkeypatch, value):
         monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", value)
         assert w.worker_enabled() is True
 
-    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "maybe"])
-    def test_off_for_everything_else(self, monkeypatch, value):
-        # ⚠ Asymmetric on purpose: a typo must not silently enable a new
-        # process, the same reasoning preload_enabled() uses in the other
-        # direction.
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off"])
+    def test_off_when_explicitly_disabled(self, monkeypatch, value):
         monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", value)
         assert w.worker_enabled() is False
+
+    @pytest.mark.parametrize("value", ["", "maybe"])
+    def test_an_unrecognised_value_falls_through_to_the_default(self, monkeypatch, value):
+        # A typo must not silently disable the fix.
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", value)
+        assert w.worker_enabled() is True
+
+    def test_the_1_132_0_preload_flag_turns_the_worker_off(self, monkeypatch):
+        # ⚠ That user explicitly chose the main-thread import and is entitled
+        # to keep getting it. Running both would import the stack into the very
+        # process the worker exists to keep clean.
+        monkeypatch.setenv("JDOCMUNCH_PRELOAD_EMBEDDINGS", "1")
+        assert w.worker_enabled() is False
+
+    def test_naming_the_worker_beats_the_preload_flag(self, monkeypatch):
+        monkeypatch.setenv("JDOCMUNCH_PRELOAD_EMBEDDINGS", "1")
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", "1")
+        assert w.worker_enabled() is True
 
     def test_garbage_timeout_falls_back_to_the_default(self, monkeypatch):
         monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER_TIMEOUT", "soon")
@@ -362,17 +385,14 @@ class TestProviderWiring:
         yield
         prov._reset_provider_cache()
 
-    def test_the_in_process_provider_is_still_the_default(self, monkeypatch):
+    def test_the_worker_is_used_by_default(self, monkeypatch):
         monkeypatch.delenv("JDOCMUNCH_EMBED_WORKER", raising=False)
-        sentinel = object()
-        monkeypatch.setattr(prov, "_SentenceTransformersProvider", lambda: sentinel)
-        assert prov._sentence_transformers_factory() is sentinel
-
-    def test_the_worker_is_used_when_enabled(self, monkeypatch):
-        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", "1")
+        monkeypatch.delenv("JDOCMUNCH_PRELOAD_EMBEDDINGS", raising=False)
         seen = {}
 
         class _Stub:
+            spawn_failed = False
+
             def __init__(self, model_name):
                 seen["model"] = model_name
 
@@ -380,6 +400,65 @@ class TestProviderWiring:
         monkeypatch.setenv("JDOCMUNCH_ST_MODEL", "some-model")
         assert isinstance(prov._sentence_transformers_factory(), _Stub)
         assert seen["model"] == "some-model"
+
+    def test_the_in_process_provider_is_used_when_the_worker_is_disabled(self, monkeypatch):
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", "0")
+
+        class _InProcess:
+            DEFAULT_MODEL = "some-model"
+
+        monkeypatch.setattr(prov, "_SentenceTransformersProvider", _InProcess)
+        assert isinstance(prov._sentence_transformers_factory(), _InProcess)
+
+    def test_a_child_that_cannot_spawn_falls_back_in_process(self, monkeypatch):
+        """⚠⚠ The guard that makes defaulting the worker ON safe.
+
+        Without it, anyone whose ``sys.executable`` cannot be spawned — a
+        frozen bundle, a locked-down sandbox — silently loses semantic search
+        that works for them today. That is a NEW defect traded for jdoc#118's,
+        which is not a trade to make on a user's behalf.
+        """
+        monkeypatch.delenv("JDOCMUNCH_EMBED_WORKER", raising=False)
+        monkeypatch.setenv("JDOCMUNCH_ST_MODEL", "some-model")
+
+        class _Unspawnable:
+            spawn_failed = True
+
+            def __init__(self, model_name):
+                pass
+
+        class _InProcess:
+            # ⚠ `_st_model_name` reads DEFAULT_MODEL off this class eagerly,
+            # even when JDOCMUNCH_ST_MODEL is set, so a bare lambda stub blows
+            # up before the code under test runs.
+            DEFAULT_MODEL = "some-model"
+
+        monkeypatch.setattr(w, "WorkerProvider", _Unspawnable)
+        monkeypatch.setattr(prov, "_SentenceTransformersProvider", _InProcess)
+        assert isinstance(prov._sentence_transformers_factory(), _InProcess)
+
+    def test_a_real_unspawnable_command_sets_spawn_failed(self, tmp_path):
+        # Through the real Popen, not a stub: the flag is only worth anything
+        # if an actual spawn failure sets it.
+        provider = w.WorkerProvider(
+            "fake-model", command=[str(tmp_path / "no-such-interpreter")],
+        )
+        assert provider.spawn_failed is True
+
+    def test_a_child_that_dies_later_does_not_fall_back_in_process(self, tmp_path):
+        """A restart failure must NOT import the stack into a running server.
+
+        By then the child HAS run, so the machine can spawn; something else
+        broke. Recovering semantic search by importing in-process would trade a
+        degraded feature for the deadlock this module exists to prevent.
+        """
+        provider = w.WorkerProvider("fake-model", command=_fake_child(tmp_path, "die_on_ready"))
+        try:
+            with pytest.raises(w.EmbedWorkerError):
+                provider.embed_texts(["x"])
+            assert provider.spawn_failed is False
+        finally:
+            provider.close()
 
     def test_the_import_probe_is_skipped_when_the_worker_owns_the_import(self, monkeypatch):
         # The probe protects THIS process from an import it no longer performs.
@@ -396,7 +475,7 @@ class TestProviderWiring:
         assert called == []
 
     def test_the_import_probe_still_runs_without_the_worker(self, monkeypatch):
-        monkeypatch.delenv("JDOCMUNCH_EMBED_WORKER", raising=False)
+        monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", "0")
         called = []
         monkeypatch.setattr(
             prov, "_sentence_transformers_imports_cleanly",
@@ -440,7 +519,7 @@ def test_the_identity_header_does_not_change_when_the_worker_is_enabled(monkeypa
     — jdoc#109's escalation, triggered by a refactor rather than a rotation.
     """
     monkeypatch.setenv("JDOCMUNCH_ST_MODEL", "all-MiniLM-L6-v2")
-    monkeypatch.delenv("JDOCMUNCH_EMBED_WORKER", raising=False)
+    monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", "0")
     without = prov._provider_identity("sentence-transformers")
     signature_without = prov._provider_signature("sentence-transformers")
     monkeypatch.setenv("JDOCMUNCH_EMBED_WORKER", "1")

--- a/tests/test_subprocess_stdin_guard.py
+++ b/tests/test_subprocess_stdin_guard.py
@@ -34,6 +34,22 @@ _NOT_SERVER_PATH = {
     "service_installer.py",
 }
 
+# Server-path modules whose child speaks a protocol over stdin, so `PIPE` is
+# the correct value rather than an oversight. ⚠ This is the escape hatch this
+# file's own docstring names — an explicit list with a reason, not a loosened
+# rule. The hazard DEVNULL prevents is a child blocking on a pipe nobody
+# writes to; a child the parent is actively writing to and killing on a
+# timeout is the opposite case.
+#
+# ⚠ Entries here are still bound by every other rule: the module must pass
+# `stdin=` explicitly, and it must not inherit fd 0.
+_INTENTIONAL_STDIN_PIPE = {
+    "embeddings/worker.py": (
+        "jdoc#118: the sentence-transformers child is driven over a private "
+        "NDJSON pipe on its stdin, and the parent bounds and kills it."
+    ),
+}
+
 
 def _spawn_sites() -> list[tuple[str, int, bool]]:
     """(relative_path, lineno, passes_stdin) for every subprocess spawn in src."""
@@ -91,14 +107,14 @@ def test_no_server_path_subprocess_inherits_stdin():
 def test_server_path_stdin_is_devnull():
     """`stdin=` alone isn't enough: PIPE would reintroduce a blocking child.
 
-    jdoc has no LSP-style child that speaks over stdin, so DEVNULL is the only
-    correct value here. If that ever changes, add the module to an explicit
-    intentional-PIPE list rather than loosening this.
+    DEVNULL is the only correct value except in the modules named in
+    `_INTENTIONAL_STDIN_PIPE`, which drive a child over stdin on purpose.
+    Add a module there, with its reason, rather than loosening this.
     """
     wrong: list[str] = []
     for path in sorted(SRC_ROOT.rglob("*.py")):
         rel = path.relative_to(SRC_ROOT).as_posix()
-        if rel in _NOT_SERVER_PATH:
+        if rel in _NOT_SERVER_PATH or rel in _INTENTIONAL_STDIN_PIPE:
             continue
         tree = ast.parse(path.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
@@ -128,5 +144,39 @@ def test_exemption_list_has_no_dead_entries():
     than leaving standing cover for a future call site at the same path.
     """
     spawning = {rel for rel, _, _ in _spawn_sites()}
-    dead = _NOT_SERVER_PATH - spawning
+    dead = (_NOT_SERVER_PATH | set(_INTENTIONAL_STDIN_PIPE)) - spawning
     assert not dead, f"exemption entries no longer spawn any process: {sorted(dead)}"
+
+
+def test_intentional_pipe_modules_really_pass_pipe():
+    """The narrow exemption must not become cover for a missing `stdin=`.
+
+    A module on that list is excused from DEVNULL and from nothing else. If its
+    spawn stops passing `stdin=subprocess.PIPE`, the entry is describing a call
+    site that no longer exists and the real one is unguarded.
+    """
+    seen: dict[str, list[str]] = {rel: [] for rel in _INTENTIONAL_STDIN_PIPE}
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        rel = path.relative_to(SRC_ROOT).as_posix()
+        if rel not in _INTENTIONAL_STDIN_PIPE:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (
+                isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "subprocess"
+                and func.attr in _SPAWNERS
+            ):
+                continue
+            for kw in node.keywords:
+                if kw.arg == "stdin" and isinstance(kw.value, ast.Attribute):
+                    seen[rel].append(kw.value.attr)
+    for rel, values in seen.items():
+        assert "PIPE" in values, (
+            f"{rel} is exempted as an intentional stdin=PIPE site but passes "
+            f"{values or 'nothing'}; drop the exemption or fix the call"
+        )


### PR DESCRIPTION
Closes #118.

v1.132.0 shipped a switch between two outages and said so. The import was
either on the main thread (cold `torch` measured 73.77 s, past a 30 s connect
timeout) or on a background thread (Windows loader lock, wedged indefinitely).
Both contracts cannot hold in one process, so the process is the thing to
change: `sentence-transformers` now loads in a child, concurrently with the
live server and alone in its own loader.

**On by default.** An opt-in worker would have been a third switch on a pile of
two, which is why #118 stayed open after v1.132.0 — "pick your outage" is the
defect restated as configuration. `JDOCMUNCH_EMBED_WORKER=0` opts out and
`JDOCMUNCH_PRELOAD_EMBEDDINGS=1` still selects the v1.132.0 behaviour.

One method crosses the boundary: `embed_texts`. numpy stays in the server —
`doc_store` and `related_persist` use it to score.

⚠ Defaulting it required the spawn-failure fallback first: a child that cannot
be spawned at all falls back in-process, because otherwise anyone with an
unusual `sys.executable` silently loses semantic search that works for them
today. A child that dies *later* does not fall back.

⚠ No A/B — the wedge still will not reproduce. What is asserted instead is
deterministic: after a real embed, the server's `sys.modules` holds none of
`sentence_transformers`/`transformers`/`torch`/`scipy`/`sklearn`. Unreachable
rather than unobserved.

Measured: `initialize` inside run-to-run noise of the in-process default
(+0.04 s over 3 runs) vs +5.6 s for the v1.132.0 preload; 1000 sections 1.72 s
through the pipe vs 1.64 s in-process.

Suite 2538 passed / 6 skipped; `ruff check src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
