### PR TITLE
fix(packaging): declare PEP 639 license expression for PyPI allowlisting

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/jgravelle/jdocmunch-mcp#readme",
   "repository": "https://github.com/jgravelle/jdocmunch-mcp",
-  "license": "LicenseRef-Dual-Use",
+  "license": "LicenseRef-jDocMunch-Dual-Use",
   "keywords": [
     "docs",
     "mcp",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [Unreleased]
+
+### PyPI published no license identifier at all (#122, @marcelruhf)
+
+`pyproject.toml` had no `license` key, so PyPI left `info.license` and
+`info.license_expression` empty and a commercial user could not allowlist us
+by identifier. Packaging metadata is PEP 639 now:
+`license = "LicenseRef-jDocMunch-Dual-Use"` plus
+`license-files = ["LICENSE"]`.
+
+The LICENSE file is unchanged and still ships.
+
+⚠ **PyPI metadata is immutable per version, so this starts at the next release.**
+Every version up to 1.135.0 keeps empty license fields.
+
+⚠⚠ **The report named one surface and the licence is declared on three.**
+`.claude-plugin/plugin.json` and the mcpb manifest both said
+`LicenseRef-Dual-Use` — no product prefix — so an allowlist keyed on the
+identifier still needed two entries. That is the reported defect one surface
+over, and fixing only what was reported would have left it. Both now name the
+same identifier, and the mcpb generator DERIVES it from `pyproject.toml` rather
+than carrying its own copy, which is how the two spellings drifted apart to
+begin with.
+
+⚠ **LICENSE has no Version line, so the identifier has no version suffix.**
+jcodemunch-mcp #518 pins the suffix to LICENSE's `Version X.Y` so 1.2 cannot
+ship under 1.1's identifier. The same ratchet is here: if a Version line
+appears without a matching suffix (or the reverse), the build fails.
+`tests/test_license_identifier_agreement.py` is that pin.
+
 ## [1.135.0] - 2026-08-18 - list_repos stops parsing the files it throws away
 
 `list_repos` globbed `*/*.json` and excluded only `_`-prefixed files and

--- a/mcpb/build.py
+++ b/mcpb/build.py
@@ -58,7 +58,7 @@ def build_manifest():
         "homepage": f"https://github.com/jgravelle/{name}",
         "documentation": f"https://github.com/jgravelle/{name}#readme",
         "support": f"https://github.com/jgravelle/{name}/issues",
-        "license": "LicenseRef-Dual-Use",
+        "license": pyproject_field("license"),
         "server": {
             "type": "python",
             "entry_point": "server/main.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ requires-python = ">=3.10"
 authors = [
     { name = "J. Gravelle", email = "j@gravelle.us" },
 ]
+license = "LicenseRef-jDocMunch-Dual-Use"
+license-files = ["LICENSE"]
 dependencies = [
     "mcp>=1.10.0,<2.0.0",
     "httpx>=0.27.0",

--- a/tests/test_license_identifier_agreement.py
+++ b/tests/test_license_identifier_agreement.py
@@ -1,0 +1,109 @@
+"""Every surface that declares our license must name the same identifier.
+
+The packaging PR switched metadata to a PEP 639 expression so a commercial
+user could allowlist the license BY IDENTIFIER. PyPI currently publishes
+neither info.license nor info.license_expression. That fixed the surface
+they hit and left two others declaring `LicenseRef-Dual-Use` — no product
+prefix — so an allowlist keyed on the identifier still needed two entries.
+Same defect as the one that was fixed, one surface over.
+
+LICENSE currently has no Version line, so the identifier has no version
+suffix. If a Version line is added later, the identifier must pick it up;
+the reverse must also fail. That is the jcodemunch-mcp #518 ratchet.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PLUGIN_JSON = REPO_ROOT / ".claude-plugin" / "plugin.json"
+LICENSE = REPO_ROOT / "LICENSE"
+
+# SPDX 3.0 §10.1: LicenseRef-[idstring], idstring = [A-Za-z0-9.-]+
+_LICENSE_REF = re.compile(r"^LicenseRef-[A-Za-z0-9.-]+$")
+
+
+def _declared_expression() -> str:
+    """pyproject.toml is the source; every other surface is checked against it."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r'^license\s*=\s*"([^"]+)"', text, re.M)
+    assert match, (
+        "pyproject.toml no longer declares `license` as a bare string. If it "
+        "has no license key, PyPI leaves info.license and info.license_expression "
+        "empty and the identifier is unallowlistable again."
+    )
+    return match.group(1)
+
+
+def test_the_declared_expression_is_a_well_formed_license_ref() -> None:
+    expression = _declared_expression()
+    assert _LICENSE_REF.match(expression), (
+        f"{expression!r} is not a valid SPDX LicenseRef; PyPI rejects a "
+        "malformed license expression at upload, i.e. after the wheel is built"
+    )
+
+
+def test_plugin_manifest_names_the_same_identifier() -> None:
+    declared = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))["license"]
+    assert declared == _declared_expression(), (
+        f".claude-plugin/plugin.json says {declared!r}; pyproject.toml says "
+        f"{_declared_expression()!r}. Two identifiers for one license means an "
+        "allowlist needs two entries."
+    )
+
+
+def test_mcpb_manifest_derives_the_identifier_rather_than_copying_it() -> None:
+    """`mcpb/manifest.json` is generated, so the check belongs on the generator.
+
+    Asserting the built value (not the source text) is what makes this fail if
+    someone reintroduces a literal, whatever they spell it.
+    """
+    sys.path.insert(0, str(REPO_ROOT / "mcpb"))
+    try:
+        from build import build_manifest  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+    assert build_manifest()["license"] == _declared_expression()
+
+
+def test_the_identifier_tracks_the_license_file_version() -> None:
+    """LICENSE version and identifier suffix must stay in lockstep.
+
+    jcodemunch-mcp #518 pins a suffix so 1.2 cannot ship under 1.1's identifier.
+    These LICENSE files currently have no Version line, so the identifier must
+    not invent one. Adding Version X.Y without a matching suffix (or the reverse)
+    fails here.
+    """
+    expression = _declared_expression()
+    suffix = re.search(r"-(\d+\.\d+)$", expression)
+    header = LICENSE.read_text(encoding="utf-8")[:400]
+    in_file = re.search(r"^Version\s+(\d+\.\d+)", header, re.M)
+    if in_file:
+        assert suffix, (
+            f"{expression!r} carries no version suffix but {LICENSE.name} "
+            f"says Version {in_file.group(1)}"
+        )
+        assert suffix.group(1) == in_file.group(1), (
+            f"the identifier claims license version {suffix.group(1)}; "
+            f"{LICENSE.name} says {in_file.group(1)}"
+        )
+    else:
+        assert not suffix, (
+            f"{expression!r} carries version suffix {suffix.group(1)} but "
+            f"{LICENSE.name} has no Version line"
+        )
+
+
+def test_no_license_classifier_survives_beside_the_expression() -> None:
+    """PEP 639: a `License ::` classifier alongside an expression is rejected.
+
+    The build succeeds and the UPLOAD fails, which is the expensive ordering.
+    """
+    text = PYPROJECT.read_text(encoding="utf-8")
+    offenders = re.findall(r'^\s*"(License :: [^"]+)"', text, re.M)
+    assert not offenders, f"remove the classifier(s) {offenders}; the expression supersedes them"


### PR DESCRIPTION
## Human summary

We have a commercial license, but this package currently publishes with no license identifier on PyPI at all (`info.license` and `info.license_expression` are both empty), so it cannot be allowlisted by name. I therefore propose adding a PEP 639-compliant license identifier, which can be allowlisted by package ingestion systems. An alternative I considered was setting info.license to a simple string that would easily identify the license in a way that allows for freeform allowlisting. Let me know if you would prefer that approach.

## Summary
pyproject.toml currently has no `license` key, so PyPI ingestion leaves `info.license` and `info.license_expression` empty (the LICENSE file is still packaged, which is why `info.license_files` is already `["LICENSE"]`).

This adds PEP 639 metadata:
- `license = "LicenseRef-jDocMunch-Dual-Use"`
- `license-files = ["LICENSE"]`

No `License ::` classifier. The LICENSE file itself is unchanged.

## Test plan
- [x] Confirm `pyproject.toml` has `license` as the LicenseRef expression and `license-files = ["LICENSE"]`
- [x] `uv build` and check the wheel/sdist metadata for `License-Expression: LicenseRef-jDocMunch-Dual-Use` and `License-File: LICENSE`