### PR TITLE
feat(embeddings): FastEmbed provider, aliased per model not per provider

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "jdocmunch",
   "displayName": "jDocMunch",
-  "version": "1.136.1",
+  "version": "1.137.0",
   "description": "Token-efficient MCP server for structured documentation retrieval via section-level indexing",
   "author": {
     "name": "J. Gravelle",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,96 @@
 
 ## [Unreleased]
 
+## [1.137.0] - 2026-08-28 - FastEmbed, and an alias narrow enough to be safe
+
+Reported by @LuigiNicaPRO ([#126](https://github.com/jgravelle/jdocmunch-mcp/issues/126)).
+
+### Added - FastEmbed as an offline embedding provider
+
+`pip install jdocmunch-mcp[fastembed]` runs `all-MiniLM-L6-v2` through
+onnxruntime instead of torch. `JDOCMUNCH_EMBEDDING_PROVIDER=fastembed` selects
+it, `JDOCMUNCH_FASTEMBED_MODEL` picks a different model, and auto-detect
+prefers it over sentence-transformers when both are installed —
+`JDOCMUNCH_EMBEDDING_PROVIDER=sentence-transformers` is the way back.
+
+The reported defect was narrow: `get_provider_name()` is a closed if-chain, so
+`fastembed` fell through it to auto-detect and `_PROVIDER_FACTORIES` was
+unreachable for the name. A closed chain and a factory map are two lists that
+have to agree, and nothing asserted that they did; now something does.
+
+### Fixed - the sidecar alias keys on the MODEL, because the sidecar has no dim backstop
+
+Switching runtimes should not re-embed a corpus that has not changed, so the
+reporter proposed normalizing the provider name after `_get_provider()`
+resolves — the header keeps saying `sentence-transformers` and the existing
+vectors load. Right goal. The problem is that the proposed normalization is
+**unconditional**.
+
+`cache.load` matches the header by exact equality on `(provider, model, dim)`,
+and `_provider_identity` returns `dim=None` for both offline providers — which
+the cache reads as a **wildcard**. So there is nothing underneath a normalized
+provider name to catch a mismatch. `JDOCMUNCH_ST_MODEL` is user-settable, so a
+blanket rename writes `sentence-transformers` over vectors some other model
+produced, `cache.load` then **matches**, the two derivations merge into one
+sidecar, and search ranks across both. That is jdoc#111's shape, and it is
+worse than the re-embed it avoids: a full re-embed is expensive and
+observable, this is cheap and invisible.
+
+So the alias is an explicit allow-list of model ids
+(`_FASTEMBED_ST_EQUIVALENT_MODELS`), and it fails closed on every axis — an
+unlisted model, a `JDOCMUNCH_ST_MODEL` naming a different model, or an empty
+model all keep the `fastembed` provider name and re-embed. A model earns a
+place on that list by being measured identical across the two runtimes;
+`check_embedding_drift` is the measurement, since a canary captured under one
+runtime and re-run under the other reports exactly that.
+
+Two details that look like oversights and are not. The alias writes the
+sentence-transformers side's **spelling** (`all-MiniLM-L6-v2` by default), not
+the canonical hub id, because the header is an exact string match against a
+file that already exists. And the dim stays `None`: every sentence-transformers
+sidecar ever written stores `None` there, so an active dim of 384 would compare
+unequal and purge the file the alias exists to reuse — the same trap the embed
+worker documents.
+
+New `sidecar_identity()` is the single place that resolves the header triple.
+`index_local`'s rotation detector reads it too; a reader that skipped the alias
+would report a rotation on every index for a corpus that never moved
+(jdoc#109).
+
+### Fixed - the model-cache probe reads FastEmbed's cache, not HuggingFace's
+
+`_st_model_is_cached()` probes the HuggingFace hub layout, and jdoc#110's
+warmup gate calls it to decide whether a model load would block the MCP
+handshake on a download. FastEmbed downloads into its own directory
+(`FASTEMBED_CACHE_PATH`, otherwise `<tempdir>/fastembed_cache`), so the HF
+probe would answer about a directory FastEmbed does not read: it reports
+"cached" for a machine whose HF cache holds the model for torch while FastEmbed
+still has to fetch it, and warmup then stalls the handshake — jdoc#110's outage,
+which reaches the user as nothing but "connection timed out". A populated HF
+cache is deliberately **not** taken as evidence; guessing "cached" is the
+harmful guess, and guessing "not cached" costs a deferred load.
+
+### Unchanged, on purpose
+
+The sentence-transformers import probe and the embed worker do not fire for
+FastEmbed. Neither one is about embeddings in general; both are about torch.
+onnxruntime loads a different DLL set, so jdoc#118's Windows loader deadlock is
+an argument here rather than evidence, and probing a package this provider
+never imports would suppress a working provider on a machine where
+sentence-transformers happens to be broken. If FastEmbed turns out to wedge the
+same way on Windows, the worker is the fix and the measurement comes first.
+
+`fastembed` is an optional extra and never a runtime dependency — a lexical
+install must not acquire a native runtime it will never call. The first-use
+model download is README-disclosed under "Background behavior, fully disclosed"
+before shipping, per the PyPI-quarantine rule.
+
+Tests `tests/test_jdoc_126_fastembed_provider.py` (42; **41 fail pre-fix**).
+The single both-sides pass is the control that demonstrates the unconditional
+alias matching a sidecar it should not. Suite **2646 / 6**; `ruff check src/`
+clean. No tool, schema or INDEX_VERSION change.
+
+
 ## [1.136.1] - 2026-08-26 - Unverifiable is not verified
 
 ### Fixed - `verify_index` counted a section it could not verify as verified

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,72 @@
 # jdocmunch-mcp
 
-**Version:** 1.136.1 |
+**Version:** 1.137.0 |
 **Tests:** `PYTHONPATH=src pytest tests/ -q`
+
+## v1.137.0 — #126: the alias keys on the MODEL, because the sidecar has no dim backstop
+
+FastEmbed as an offline provider (`[fastembed]` extra, onnxruntime not torch),
+reported by @LuigiNicaPRO. The reported defect is narrow — `get_provider_name()`
+is a closed if-chain, so `fastembed` fell through it to auto-detect and
+`_PROVIDER_FACTORIES` was unreachable for the name. ⚠ **A closed chain and a
+factory map are two lists that must agree and nothing asserted it**; a test now
+does, and it asserts the resolved name EQUALS the requested one — the weaker
+`name in _PROVIDER_FACTORIES` form passes pre-fix, because an unrecognised
+spelling resolves to something else.
+
+⚠⚠ **The reported remedy — normalize the provider name so the header keeps
+saying `sentence-transformers` — is UNCONDITIONAL, and that is the whole
+finding.** `cache.load` matches `(provider, model, dim)` by exact equality and
+`_provider_identity` returns `dim=None` for BOTH offline providers, which the
+cache reads as a **wildcard**. So there is no dim backstop underneath a
+normalized provider name. `JDOCMUNCH_ST_MODEL` is user-settable, so a blanket
+rename writes `sentence-transformers` over vectors another model produced,
+`cache.load` then MATCHES, and the two derivations merge into one sidecar that
+search ranks across. **jdoc#111's shape, and worse than the re-embed it avoids:
+a full re-embed is expensive and observable, this is cheap and invisible.**
+
+`_FASTEMBED_ST_EQUIVALENT_MODELS` is an explicit per-model allow-list, failing
+closed on an unlisted model, a divergent `JDOCMUNCH_ST_MODEL`, and an empty
+model. ⚠ **A model earns a place there by being MEASURED**, and
+`check_embedding_drift` is the measurement — a canary captured under one runtime
+and re-run under the other reports exactly the equivalence being claimed.
+
+⚠ Two details that read as oversights and are not. The alias writes the
+sentence-transformers **SPELLING** (`all-MiniLM-L6-v2`), not the canonical hub
+id, because the header is an exact string match against a file that already
+exists. And **dim stays `None`** — every ST sidecar ever written stores `None`,
+so an active 384 compares unequal and purges the file the alias exists to reuse
+(the same trap `_sentence_transformers_factory` documents for the worker).
+
+⚠ New `sidecar_identity()` is the ONE place resolving the header triple;
+`index_local`'s rotation detector reads it too, or it reports a rotation on every
+index for a corpus that never moved (jdoc#109).
+
+⚠⚠ **The cache probe is provider-aware, and this is a jdoc#110 regression
+waiting to happen.** `_st_model_is_cached` probes the HF hub layout; FastEmbed
+downloads to `FASTEMBED_CACHE_PATH` / `<tempdir>/fastembed_cache`. Sharing the
+probe reports "cached" for a machine whose HF cache holds the model for TORCH
+while FastEmbed still fetches it — warmup then blocks the handshake on a
+download, which reaches the user as nothing but "connection timed out". **A
+populated HF cache is deliberately NOT evidence**: guessing "cached" is the
+harmful guess, "not cached" costs a deferred load.
+
+⚠ **The ST import probe and the embed worker do NOT fire for FastEmbed.**
+Neither is about embeddings; both are about torch. onnxruntime loads a different
+DLL set, so jdoc#118 is an ARGUMENT here and not evidence — and probing a package
+this provider never imports would suppress a working provider on a machine where
+sentence-transformers is broken. If FastEmbed wedges the same way on Windows the
+worker is the fix, and the measurement comes first.
+
+⚠ Auto-detect prefers FastEmbed over sentence-transformers when both are
+installed; explicit `JDOCMUNCH_EMBEDDING_PROVIDER=sentence-transformers` is the
+way back. Extra is OPTIONAL, never a runtime dep. First-use model download is
+README-disclosed before release (PyPI-quarantine rule).
+
+Tests `tests/test_jdoc_126_fastembed_provider.py` (42; **41 fail pre-fix**, the
+one both-sides pass being the control that demonstrates the unconditional alias
+matching a sidecar it should not). Suite **2646 / 6**; `ruff check src/` clean.
+No tool, schema or INDEX_VERSION change.
 
 - **v1.136.0 - the one string that survives tool deferral.** The MCP `initialize` response now carries an `instructions` string; it did not before, because the transport called `create_initialization_options()` bare and the field went out empty. ⚠⚠ **Invisible in a normal session, CONCENTRATED in a deferred one**: a host over its schema budget ships tool NAMES and withholds the JSONSchemas, so an agent sees 64 bare strings and none of the descriptions. The spec delivers `instructions` on a SEPARATE TRACK from the tool list, so it arrives whole - in a plain MCP client it is the entire steering budget this server gets. 909 chars against a 1,000 cap. ⚠ Also sets `Server(..., version=__version__)`: without it the SDK reports ITS OWN version in `serverInfo`. ⚠ `__version__` is `"unknown"` under `PYTHONPATH=src`, so a green test does NOT prove the wire carries a real number. ⚠⚠ **Ported from jcodemunch-mcp v1.108.292 - both defects were present here unchanged, and neither had a symptom anyone could report.** ⚠⚠ **The port also reproduced a NameError in BOTH repos** (`logger` through a module-level name neither server.py defines) and **only jdoc caught it** - jdata's suite was GREEN with the identical bug, because it had no F821 gate. jdoc's `test_lint_gate_regressions.py` did its job. **A setting fixed in one repo of a suite is fixed in one repo, and that applies to the GATES as much as the code.** `tests/test_mcp_instructions.py` binds the prose to the catalog; all three guards were verified by reintroducing the defect each names.
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ docs/ ──► parser (per format) ──► section tree ──► local index
 - **Parsing** is per format, one module each: Markdown/MDX, reStructuredText, AsciiDoc, Jupyter notebooks, HTML, plain text, OpenAPI (YAML), JSON/JSONC, XML/SVG/XHTML, Godot scenes, and — via the optional `[office]` extra — PDF, DOCX, PPTX, and EPUB.
 - **Storage** is a versioned local index (`INDEX_VERSION = 3`) that auto-migrates on first load. A 1.x release never forces a reindex.
 - **Retrieval** is lexical BM25 by default, hybrid when embeddings are available.
-- **Embeddings are optional and provider-agnostic** — Gemini, OpenAI, an OpenAI-compatible endpoint, or local sentence-transformers. Without one, search stays lexical and entirely offline.
+- **Embeddings are optional and provider-agnostic** — Gemini, OpenAI, an OpenAI-compatible endpoint, or a local offline model through either FastEmbed (ONNX) or sentence-transformers (torch). Without one, search stays lexical and entirely offline.
 
 Deeper detail: [ARCHITECTURE.md](ARCHITECTURE.md) and [SPEC.md](SPEC.md).
 
@@ -188,6 +188,24 @@ JDOCMUNCH_SHARE_SAVINGS=0
 Embedding and summarizer providers call their configured API **only when you enable them**, and never by default. `watch-install` registers a login service **only** when you run it yourself.
 
 ### Background behavior, fully disclosed
+
+**A model download, the first time a local embedding provider runs.** Both
+offline providers fetch their model from HuggingFace on first use and cache it
+on disk. Nothing downloads until you enable embeddings, and a lexical-only
+install never contacts the hub. Startup warmup is **skipped** when the model is
+not already cached, so a first run defers the download to your first search
+rather than stalling the MCP handshake behind it
+([#110](https://github.com/jgravelle/jdocmunch-mcp/issues/110)).
+
+**FastEmbed as the offline provider.** `pip install jdocmunch-mcp[fastembed]`
+runs the same `all-MiniLM-L6-v2` model through onnxruntime instead of torch,
+which is a much smaller install. When both offline providers are present
+FastEmbed is preferred; `JDOCMUNCH_EMBEDDING_PROVIDER=sentence-transformers`
+selects the other one. On the shared model the two write the **same** vector
+store, so switching runtimes does not re-embed your corpus. Point FastEmbed at
+a different model with `JDOCMUNCH_FASTEMBED_MODEL` and it keeps its own vectors
+instead, because vectors from two models are not interchangeable
+([#126](https://github.com/jgravelle/jdocmunch-mcp/issues/126)).
 
 **A child process, when local embeddings are in use.** When the
 `sentence-transformers` provider is active, jDocMunch runs the embedding model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jdocmunch-mcp"
-version = "1.136.1"
+version = "1.137.0"
 description = "Token-efficient MCP server for structured documentation retrieval via section-level indexing"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -29,6 +29,10 @@ openai = ["openai>=1.0.0"]
 minimax = ["openai>=1.0.0"]
 zhipu = ["openai>=1.0.0"]
 semantic = ["google-generativeai>=0.8.0"]
+# jdoc#126: offline embeddings through onnxruntime instead of torch. An
+# OPTIONAL extra, never a runtime dependency -- a lexical install must not
+# acquire a native runtime it will never call.
+fastembed = ["fastembed>=0.8.0"]
 office = ["markitdown[pdf,docx,pptx]>=0.1.6"]
 
 [project.scripts]

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.jgravelle/jdocmunch-mcp",
   "title": "jDocmunch MCP",
   "description": "Section-level doc search for .md, .rst, .adoc, .ipynb, .html, .yaml, .json, and OpenAPI specs.",
-  "version": "1.136.1",
+  "version": "1.137.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "jdocmunch-mcp",
-      "version": "1.136.1",
+      "version": "1.137.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/jdocmunch_mcp/embeddings/provider.py
+++ b/src/jdocmunch_mcp/embeddings/provider.py
@@ -1,14 +1,16 @@
 """Embedding providers for semantic section search.
 
 Supports Gemini (text-embedding-004), OpenAI (text-embedding-3-small),
-OpenAI-compatible endpoints, and sentence-transformers (fully offline,
-no API key required).
+OpenAI-compatible endpoints, FastEmbed (offline, ONNX) and
+sentence-transformers (offline, torch) — neither offline provider needs a key.
 
 Auto-detection priority (first available wins):
-    1. JDOCMUNCH_EMBEDDING_PROVIDER env var (gemini/openai/openai-compatible/sentence-transformers/none)
+    1. JDOCMUNCH_EMBEDDING_PROVIDER env var
+       (gemini/openai/openai-compatible/fastembed/sentence-transformers/none)
     2. GOOGLE_API_KEY → Gemini            (opt-in, see below)
     3. OPENAI_API_KEY → OpenAI            (opt-in, see below)
-    4. sentence-transformers installed → local offline model
+    4. fastembed installed → local offline ONNX model
+    5. sentence-transformers installed → local offline torch model
 
 ⚠ Steps 2 and 3 are PAID CLOUD providers and are SKIPPED by auto-detect unless
 JDOCMUNCH_ALLOW_PAID_EMBEDDINGS is set. A bare key in the environment must not
@@ -158,6 +160,51 @@ def _st_model_name() -> str:
     )
 
 
+def _fastembed_model_name() -> str:
+    return os.environ.get(
+        "JDOCMUNCH_FASTEMBED_MODEL", _FastEmbedProvider.DEFAULT_MODEL
+    )
+
+
+def _canonical_hub_model_id(model: str) -> str:
+    """Resolve a bare model name to the hub id both runtimes actually load.
+
+    sentence-transformers accepts ``all-MiniLM-L6-v2`` and resolves it on the
+    hub to ``sentence-transformers/all-MiniLM-L6-v2``; FastEmbed requires the
+    qualified spelling. The two spellings name ONE model, so the equivalence
+    check below compares canonical ids rather than whatever the user typed.
+    """
+    model = (model or "").strip()
+    if not model or "/" in model:
+        return model
+    return f"sentence-transformers/{model}"
+
+
+# ---------------------------------------------------------------------------
+# FastEmbed ⇄ sentence-transformers vector equivalence (jdoc#126)
+# ---------------------------------------------------------------------------
+#
+# ⚠⚠ An ALLOW-LIST OF MODELS, never a blanket rename of the provider. The
+# sidecar header is matched by exact equality on (provider, model, dim), and
+# ``_provider_identity`` returns dim=None for both offline providers — the
+# cache treats that as a WILDCARD, so there is no dim backstop underneath a
+# normalized provider name. Writing "sentence-transformers" over vectors that
+# some other runtime produced would therefore make ``cache.load`` MATCH: the
+# two derivations merge into one sidecar and search ranks across both,
+# silently. That is jdoc#111's shape, and it is worse than the full re-embed
+# it avoids — a re-embed is expensive and observable, this is cheap and
+# invisible.
+#
+# A model earns a place here by being MEASURED identical across the two
+# runtimes, not by looking like it should be. ``check_embedding_drift`` is the
+# measurement: capture a canary under one runtime, re-run it under the other,
+# and read ``max_drift``. Anything not named here is written under the
+# ``fastembed`` provider name and re-embedded, which is the fail-closed side.
+_FASTEMBED_ST_EQUIVALENT_MODELS = frozenset({
+    "sentence-transformers/all-MiniLM-L6-v2",
+})
+
+
 def _st_model_is_cached(model: str) -> bool:
     """Whether ``model`` already sits in the local HuggingFace cache (jdoc#110).
 
@@ -199,13 +246,89 @@ def _st_model_is_cached(model: str) -> bool:
         candidates = [model]
         if "/" not in model:
             candidates.append(f"sentence-transformers/{model}")
+        return _hub_cache_has_model(base, candidates)
+    except OSError:
+        return True
+
+
+def _hub_cache_has_model(base, candidates: list) -> bool:
+    """Whether any of ``candidates`` has a populated snapshot dir under ``base``.
+
+    Split out of :func:`_st_model_is_cached` so the FastEmbed probe reads the
+    same layout rather than a second hand-copied version of it.
+    """
+    for cand in candidates:
+        snapshots = base / ("models--" + cand.replace("/", "--")) / "snapshots"
+        if snapshots.is_dir() and any(snapshots.iterdir()):
+            return True
+    return False
+
+
+def _fastembed_model_is_cached(model: str) -> bool:
+    """Whether ``model`` is already downloaded for FastEmbed (jdoc#126).
+
+    ⚠⚠ FastEmbed does NOT use the HuggingFace hub cache by default — it
+    downloads into its own directory (``FASTEMBED_CACHE_PATH``, otherwise
+    ``<tempdir>/fastembed_cache``). Answering this question with
+    :func:`_st_model_is_cached` would probe the wrong directory: it reports
+    "cached" for a machine whose HF cache holds the model for torch while
+    FastEmbed still has to download it, which reintroduces jdoc#110's outage —
+    a model download inside the MCP client's connect timeout, reported to the
+    user as nothing but "connection timed out".
+
+    ⚠ Only FastEmbed's own roots are probed. A populated HuggingFace hub cache
+    is NOT taken as evidence — FastEmbed passes its own ``cache_dir`` to
+    ``snapshot_download``, so an HF copy may well be there while FastEmbed
+    still downloads. Reading it as "cached" is the harmful guess in exactly the
+    direction jdoc#110 is about, and "not cached" costs only a deferred load.
+
+    Same fail-open-on-error discipline as the sentence-transformers probe: an
+    unreadable cache is not evidence of absence.
+    """
+    if not model:
+        return True
+    import tempfile
+    from pathlib import Path
+    candidates = [model, _canonical_hub_model_id(model)]
+    fe_root = os.environ.get("FASTEMBED_CACHE_PATH", "").strip()
+    root = Path(fe_root) if fe_root else Path(tempfile.gettempdir()) / "fastembed_cache"
+    try:
+        if not root.exists():
+            return False
+        if _hub_cache_has_model(root, candidates):
+            return True
+        # FastEmbed also stores some models as a flat directory named after
+        # the model rather than in the `models--` layout.
         for cand in candidates:
-            snapshots = base / ("models--" + cand.replace("/", "--")) / "snapshots"
-            if snapshots.is_dir() and any(snapshots.iterdir()):
+            flat = root / cand.replace("/", "_")
+            if flat.is_dir() and any(flat.iterdir()):
                 return True
         return False
     except OSError:
         return True
+
+
+def _active_model_is_cached(name: str) -> bool:
+    """Cache probe for whichever offline provider ``name`` selects."""
+    if name == "fastembed":
+        return _fastembed_model_is_cached(_fastembed_model_name())
+    return _st_model_is_cached(_st_model_name())
+
+
+def _fastembed_available() -> bool:
+    """Return True if fastembed is importable.
+
+    Answered from package METADATA for the same reason
+    :func:`_sentence_transformers_available` is: this runs from
+    ``get_provider_name()`` on the startup path, and detection must not be the
+    thing that pays for an import.
+    """
+    try:
+        import importlib.metadata as _md
+        _md.version("fastembed")
+        return True
+    except Exception:
+        return False
 
 
 def _sentence_transformers_available() -> bool:
@@ -284,6 +407,8 @@ def get_provider_name() -> Optional[str]:
         if _openai_compat_url() and _openai_compat_model():
             return "openai-compatible"
         return None
+    if explicit in ("fastembed", "fast-embed", "onnx"):
+        return "fastembed"
     if explicit in ("sentence-transformers", "sentence_transformers", "local"):
         return "sentence-transformers"
     if explicit == "none":
@@ -306,6 +431,14 @@ def get_provider_name() -> Optional[str]:
                 )
             continue
         return name
+    # jdoc#126: FastEmbed outranks sentence-transformers when both are
+    # installed. It reaches the same vectors for the aliased model through
+    # onnxruntime instead of torch, so it is the cheaper of two equal answers.
+    # ⚠ Naming either provider explicitly still wins — this only decides what
+    # an unconfigured machine gets, and `JDOCMUNCH_EMBEDDING_PROVIDER=
+    # sentence-transformers` is the way back.
+    if _fastembed_available():
+        return "fastembed"
     if _sentence_transformers_available():
         return "sentence-transformers"
     return None
@@ -425,6 +558,46 @@ class _OpenAICompatibleProvider:
 
 
 # ---------------------------------------------------------------------------
+# FastEmbed provider (fully offline, ONNX runtime)
+# ---------------------------------------------------------------------------
+
+class _FastEmbedProvider:
+    """Embed via FastEmbed (all-MiniLM-L6-v2 by default, 384 dims).
+
+    Runs entirely offline and pulls in onnxruntime rather than torch. Install
+    with::
+
+        pip install jdocmunch-mcp[fastembed]
+
+    Override the model with the JDOCMUNCH_FASTEMBED_MODEL env var. ⚠ Doing so
+    leaves the equivalence allow-list unless the new id is named there, so the
+    sidecar is written under the ``fastembed`` provider name and the corpus is
+    re-embedded. That is deliberate — see
+    :data:`_FASTEMBED_ST_EQUIVALENT_MODELS`.
+    """
+
+    DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+    BATCH_SIZE = 64
+
+    def __init__(self):
+        from fastembed import TextEmbedding
+        model_name = _fastembed_model_name()
+        self.model_name = model_name
+        self._model = TextEmbedding(model_name=model_name)
+
+    def embed_texts(self, texts: list, task_type: str = "retrieval_document") -> list:
+        # task_type is ignored — MiniLM is symmetric, matching the
+        # sentence-transformers provider's treatment of the same model.
+        if not texts:
+            return []
+        try:
+            return [list(map(float, vec))
+                    for vec in self._model.embed(texts, batch_size=self.BATCH_SIZE)]
+        except Exception:
+            return [[] for _ in texts]
+
+
+# ---------------------------------------------------------------------------
 # sentence-transformers provider (fully offline)
 # ---------------------------------------------------------------------------
 
@@ -518,6 +691,7 @@ _PROVIDER_FACTORIES: dict = {
     "gemini": _GeminiProvider,
     "openai": _OpenAIProvider,
     "openai-compatible": _OpenAICompatibleProvider,
+    "fastembed": _FastEmbedProvider,
     "sentence-transformers": _sentence_transformers_factory,
 }
 
@@ -537,6 +711,8 @@ def _provider_signature(name: str) -> tuple:
     """Compute a cache key that invalidates when env-driven model choice changes."""
     if name == "sentence-transformers":
         return (name, os.environ.get("JDOCMUNCH_ST_MODEL", _SentenceTransformersProvider.DEFAULT_MODEL))
+    if name == "fastembed":
+        return (name, _fastembed_model_name())
     if name == "gemini":
         return (name, _GeminiProvider.MODEL, os.environ.get("GOOGLE_API_KEY", "")[:8])
     if name == "openai":
@@ -628,7 +804,57 @@ def _provider_identity(name: str) -> tuple[str, Optional[int]]:
             os.environ.get("JDOCMUNCH_ST_MODEL", _SentenceTransformersProvider.DEFAULT_MODEL),
             None,
         )
+    if name == "fastembed":
+        return (_fastembed_model_name(), None)
     return (name, None)
+
+
+def _fastembed_aliases_to_st() -> bool:
+    """Whether the active FastEmbed model may reuse a sentence-transformers sidecar.
+
+    Every condition must hold, and each one fails CLOSED:
+
+    * the configured FastEmbed model canonicalises into
+      :data:`_FASTEMBED_ST_EQUIVALENT_MODELS` — an unmeasured model never
+      inherits another runtime's vectors;
+    * it canonicalises to the SAME model the sentence-transformers side would
+      load. ``JDOCMUNCH_ST_MODEL`` is user-settable, so a machine configured
+      for two different models has two different vector spaces and must keep
+      two sidecars.
+    """
+    fe = _canonical_hub_model_id(_fastembed_model_name())
+    st = _canonical_hub_model_id(_st_model_name())
+    return bool(fe) and fe == st and fe in _FASTEMBED_ST_EQUIVALENT_MODELS
+
+
+def sidecar_identity(name: str) -> tuple[str, str, Optional[int]]:
+    """Return the ``(provider, model, dim)`` triple written to the sidecar header.
+
+    Usually the runtime's own name and identity. The one exception is jdoc#126:
+    FastEmbed and sentence-transformers loading the SAME allow-listed model
+    produce interchangeable vectors, so re-embedding a whole corpus to swap
+    runtimes buys nothing. Inside the allow-list FastEmbed writes the
+    sentence-transformers identity and reuses the existing sidecar.
+
+    ⚠⚠ The model string is the sentence-transformers side's SPELLING
+    (``_st_model_name()``), not the canonical hub id. The header is matched by
+    exact string equality, and an existing sidecar carries whatever the user
+    configured — bare ``all-MiniLM-L6-v2`` by default. Writing the canonical id
+    would fail to match the very file this exists to reuse.
+
+    ⚠ Dim stays ``None``. The stored header says ``None`` for every
+    sentence-transformers sidecar ever written, and an active dim of 384 would
+    compare unequal to it and purge the file — the same trap
+    :func:`_sentence_transformers_factory` documents for the embed worker.
+
+    ⚠ Every caller that reads the sidecar identity must call THIS, not
+    ``_provider_identity``, or the reader disagrees with the writer and reports
+    a rotation that never happened (the jdoc#109 lesson).
+    """
+    if name == "fastembed" and _fastembed_aliases_to_st():
+        return ("sentence-transformers", _st_model_name(), None)
+    model, dim = _provider_identity(name)
+    return (name, model, dim)
 
 
 def embed_sections(
@@ -667,8 +893,10 @@ def embed_sections(
     if not provider:
         return sections
 
-    provider_name = get_provider_name() or ""
-    model, dim = _provider_identity(provider_name)
+    # jdoc#126: the header identity, which is the runtime's own name except
+    # when an allow-listed model lets FastEmbed reuse a sentence-transformers
+    # sidecar. Never `_provider_identity` directly — see `sidecar_identity`.
+    provider_name, model, dim = sidecar_identity(get_provider_name() or "")
     # jdoc#111: the char cap is part of the identity, not just the key salt.
     chars = _embed_chars()
 
@@ -905,8 +1133,16 @@ def warmup() -> str:
     ):
         return ""
     name = get_provider_name()
-    if name != "sentence-transformers":
+    if name not in ("sentence-transformers", "fastembed"):
         return ""
+    # ⚠ jdoc#126: the probe below is about sentence-transformers SPECIFICALLY.
+    # FastEmbed never imports that package, so probing it would answer a
+    # question about a stack this process is not going to load — and on a
+    # machine where sentence-transformers is broken it would suppress warmup
+    # for a provider that works fine. onnxruntime loads a different DLL set;
+    # jdoc#118's deadlock is an argument about torch, not evidence about ONNX,
+    # so FastEmbed gets neither the probe nor the worker.
+    #
     # jdoc#118: prove the provider can import BEFORE importing it here. An
     # in-process attempt that deadlocks in the native loader is unkillable and
     # poisons every subsequent library load in this process, so a failure here
@@ -915,7 +1151,11 @@ def warmup() -> str:
     # ⚠ With the worker enabled the import happens in a child, so warming is
     # both safe and worth doing on this daemon thread: the wait is bounded and
     # the child, unlike a wedged thread, can be killed.
-    if not _embed_worker_enabled() and not _sentence_transformers_imports_cleanly():
+    if (
+        name == "sentence-transformers"
+        and not _embed_worker_enabled()
+        and not _sentence_transformers_imports_cleanly()
+    ):
         logger.warning(
             "skipping embedding warmup: sentence-transformers could not be "
             "imported in a probe subprocess (%s). Lexical search is "
@@ -923,7 +1163,7 @@ def warmup() -> str:
             _import_probe_detail or "unknown",
         )
         return ""
-    if not _st_model_is_cached(_st_model_name()):
+    if not _active_model_is_cached(name):
         # ⚠⚠ Deferring the load hands the chatter problem to the first tool
         # call, which is precisely the framing hazard warmup was built to
         # avoid — and by then stdout belongs to JSON-RPC and cannot be
@@ -935,7 +1175,7 @@ def warmup() -> str:
             "embedding model %s is not in the local cache; skipping startup "
             "warmup so the MCP handshake is not blocked by a download "
             "(jdoc#110). It will load on first use.",
-            _st_model_name(),
+            _fastembed_model_name() if name == "fastembed" else _st_model_name(),
         )
         return ""
     try:

--- a/src/jdocmunch_mcp/tools/index_local.py
+++ b/src/jdocmunch_mcp/tools/index_local.py
@@ -2196,10 +2196,15 @@ def index_local(
             # header from the provider module's own view, so reading it from
             # anywhere else lets the detector disagree with the writer and
             # report a rotation that never happened.
-            _provider_identity = _emb_provider._provider_identity
+            # ⚠ jdoc#126: `sidecar_identity`, not `_provider_identity` — the
+            # writer applies the FastEmbed alias and a reader that skips it
+            # sees a rotation on every index for a corpus that never moved.
+            _sidecar_identity = _emb_provider.sidecar_identity
             _active_provider = _emb_provider.get_provider_name() or ""
             if _active_provider:
-                _active_model, _active_dim = _provider_identity(_active_provider)
+                _active_provider, _active_model, _active_dim = _sidecar_identity(
+                    _active_provider
+                )
                 # jdoc#111: the embed char cap is part of the identity, so
                 # raising JDOCMUNCH_EMBED_CHARS escalates exactly like a model
                 # change. Without this, a cap change on an unchanged corpus

--- a/tests/test_jdoc_126_fastembed_provider.py
+++ b/tests/test_jdoc_126_fastembed_provider.py
@@ -381,15 +381,31 @@ class TestCacheProbeIsProviderAware:
 # The extra stays optional, and the download is disclosed
 # ---------------------------------------------------------------------------
 
-def test_fastembed_is_an_optional_extra_not_a_dependency():
-    import tomllib
+def _pyproject_section(name: str) -> str:
+    """Body of one pyproject table, read WITHOUT tomllib.
+
+    ⚠ tomllib is 3.11+, and this repo still supports 3.10 — the same reason
+    `test_server_json_sync.py` reads pyproject with a regex.
+    """
     from pathlib import Path
+    import re
     root = Path(__file__).resolve().parents[1]
-    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
-    assert "fastembed" in data["project"]["optional-dependencies"]
-    for dep in data["project"]["dependencies"]:
-        assert "fastembed" not in dep
-        assert "onnxruntime" not in dep
+    text = (root / "pyproject.toml").read_text(encoding="utf-8")
+    pattern = r"^\[" + re.escape(name) + r"\]\n(.*?)(?=^\[|\Z)"
+    match = re.search(pattern, text, re.M | re.S)
+    assert match, f"no [{name}] table in pyproject.toml"
+    return match.group(1)
+
+
+def test_fastembed_is_an_optional_extra_not_a_dependency():
+    extras = _pyproject_section("project.optional-dependencies")
+    assert "\nfastembed = [" in "\n" + extras
+    project = _pyproject_section("project")
+    deps = project.split("dependencies = [", 1)
+    assert len(deps) == 2, "no dependencies list in [project]"
+    runtime = deps[1].split("]", 1)[0]
+    assert "fastembed" not in runtime
+    assert "onnxruntime" not in runtime
 
 
 def test_readme_discloses_the_download():

--- a/tests/test_jdoc_126_fastembed_provider.py
+++ b/tests/test_jdoc_126_fastembed_provider.py
@@ -1,0 +1,401 @@
+"""jdoc#126 - FastEmbed as an offline embedding provider, and the one thing
+that makes reusing a sentence-transformers sidecar safe.
+
+Reported by @LuigiNicaPRO: ``JDOCMUNCH_EMBEDDING_PROVIDER=fastembed`` fell
+through ``get_provider_name()``'s closed if-chain to auto-detect, so
+``_PROVIDER_FACTORIES`` was unreachable for it.
+
+The reported remedy - normalize the provider name so the header keeps saying
+"sentence-transformers" - is UNCONDITIONAL, and that is what half of these
+tests exist to prevent. ``cache.load`` matches the header by exact equality on
+(provider, model, dim) and ``_provider_identity`` returns dim=None for both
+offline providers, which the cache treats as a WILDCARD. So there is no dim
+backstop: an unconditional alias makes the header MATCH for a model whose
+vectors are not interchangeable, the two derivations merge into one sidecar,
+and search ranks across both silently. Every alias test below therefore comes
+with its fail-closed twin.
+"""
+
+import pytest
+
+from jdocmunch_mcp.embeddings import cache as emb_cache
+from jdocmunch_mcp.embeddings import provider as prov
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in (
+        "JDOCMUNCH_EMBEDDING_PROVIDER", "JDOCMUNCH_FASTEMBED_MODEL",
+        "JDOCMUNCH_ST_MODEL", "JDOCMUNCH_EMBED_CHARS", "JDOCMUNCH_EMBED_WARMUP",
+        "GOOGLE_API_KEY", "OPENAI_API_KEY", "JDOCMUNCH_ALLOW_PAID_EMBEDDINGS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    prov._reset_provider_cache()
+    yield
+    prov._reset_provider_cache()
+
+
+# ---------------------------------------------------------------------------
+# The reported defect: the name never reached the factory map
+# ---------------------------------------------------------------------------
+
+class TestProviderNameResolves:
+    def test_explicit_fastembed_is_recognised(self, monkeypatch):
+        monkeypatch.setenv("JDOCMUNCH_EMBEDDING_PROVIDER", "fastembed")
+        assert prov.get_provider_name() == "fastembed"
+
+    @pytest.mark.parametrize(
+        "spelling", ["fastembed", "FastEmbed", " fast-embed ", "ONNX"]
+    )
+    def test_accepted_spellings(self, monkeypatch, spelling):
+        monkeypatch.setenv("JDOCMUNCH_EMBEDDING_PROVIDER", spelling)
+        assert prov.get_provider_name() == "fastembed"
+
+    def test_name_has_a_factory(self):
+        assert "fastembed" in prov._PROVIDER_FACTORIES
+
+    def test_every_resolvable_name_has_a_factory(self, monkeypatch):
+        """A closed if-chain and a factory map are two lists that must agree.
+        This is the guard the reported defect needed and did not have."""
+        for spelling in ("gemini", "openai", "fastembed", "sentence-transformers"):
+            monkeypatch.setenv("JDOCMUNCH_EMBEDDING_PROVIDER", spelling)
+            name = prov.get_provider_name()
+            # The requested provider, not whatever auto-detect fell through to.
+            # Without this equality the test passes pre-fix, because an
+            # unrecognised spelling silently resolves to something else - which
+            # is the reported defect wearing a green tick.
+            assert name == spelling, f"{spelling} resolved to {name}"
+            assert name in prov._PROVIDER_FACTORIES, name
+
+    def test_signature_distinguishes_the_model(self, monkeypatch):
+        monkeypatch.setenv("JDOCMUNCH_FASTEMBED_MODEL", "BAAI/bge-small-en-v1.5")
+        a = prov._provider_signature("fastembed")
+        monkeypatch.setenv(
+            "JDOCMUNCH_FASTEMBED_MODEL", "sentence-transformers/all-MiniLM-L6-v2"
+        )
+        assert prov._provider_signature("fastembed") != a
+
+
+# ---------------------------------------------------------------------------
+# Auto-detect precedence
+# ---------------------------------------------------------------------------
+
+class TestAutoDetectPrecedence:
+    def test_fastembed_wins_when_both_installed(self, monkeypatch):
+        monkeypatch.setattr(prov, "_fastembed_available", lambda: True)
+        monkeypatch.setattr(prov, "_sentence_transformers_available", lambda: True)
+        assert prov.get_provider_name() == "fastembed"
+
+    def test_sentence_transformers_still_reachable_when_alone(self, monkeypatch):
+        monkeypatch.setattr(prov, "_fastembed_available", lambda: False)
+        monkeypatch.setattr(prov, "_sentence_transformers_available", lambda: True)
+        assert prov.get_provider_name() == "sentence-transformers"
+
+    def test_explicit_sentence_transformers_overrides_fastembed(self, monkeypatch):
+        """The way back for anyone the new precedence would move."""
+        monkeypatch.setattr(prov, "_fastembed_available", lambda: True)
+        monkeypatch.setattr(prov, "_sentence_transformers_available", lambda: True)
+        monkeypatch.setenv("JDOCMUNCH_EMBEDDING_PROVIDER", "sentence-transformers")
+        assert prov.get_provider_name() == "sentence-transformers"
+
+    def test_neither_installed_is_still_none(self, monkeypatch):
+        monkeypatch.setattr(prov, "_fastembed_available", lambda: False)
+        monkeypatch.setattr(prov, "_sentence_transformers_available", lambda: False)
+        assert prov.get_provider_name() is None
+
+    def test_fastembed_does_not_preempt_a_named_cloud_provider(self, monkeypatch):
+        monkeypatch.setattr(prov, "_fastembed_available", lambda: True)
+        monkeypatch.setenv("JDOCMUNCH_EMBEDDING_PROVIDER", "gemini")
+        assert prov.get_provider_name() == "gemini"
+
+    def test_availability_is_answered_without_importing(self, monkeypatch):
+        """Detection runs on the startup path, so it must not be the thing
+        that pays for the import - the jdoc#118 lesson, applied up front."""
+        import builtins
+        real_import = builtins.__import__
+
+        def _boom(name, *a, **k):
+            if name.split(".")[0] == "fastembed":
+                raise AssertionError("detection imported fastembed")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", _boom)
+        assert prov._fastembed_available() in (True, False)
+
+
+# ---------------------------------------------------------------------------
+# The alias, and every way it must fail closed
+# ---------------------------------------------------------------------------
+
+ST_IDENTITY = ("sentence-transformers", "all-MiniLM-L6-v2", None)
+
+
+class TestSidecarIdentityAlias:
+    def test_default_model_aliases_to_sentence_transformers(self):
+        assert prov.sidecar_identity("fastembed") == ST_IDENTITY
+
+    def test_alias_matches_the_sentence_transformers_identity_exactly(self):
+        """The whole point: the two triples must be equal, or the sidecar is
+        not reused and the alias bought nothing."""
+        assert prov.sidecar_identity("fastembed") == prov.sidecar_identity(
+            "sentence-transformers"
+        )
+
+    def test_dim_stays_none(self):
+        """A real dim of 384 compares unequal to the None every existing
+        sentence-transformers sidecar stores, purging the file this alias
+        exists to reuse. Same trap the embed worker documents."""
+        assert prov.sidecar_identity("fastembed")[2] is None
+
+    def test_model_string_is_the_sentence_transformers_spelling(self):
+        """The header is matched by exact string equality and an existing
+        sidecar carries the bare default, so writing the canonical hub id
+        would fail to match the file this exists to reuse."""
+        assert prov.sidecar_identity("fastembed")[1] == "all-MiniLM-L6-v2"
+
+    def test_alias_honours_a_configured_st_spelling(self, monkeypatch):
+        qualified = "sentence-transformers/all-MiniLM-L6-v2"
+        monkeypatch.setenv("JDOCMUNCH_ST_MODEL", qualified)
+        assert prov.sidecar_identity("fastembed") == (
+            "sentence-transformers", qualified, None,
+        )
+
+    # --- fail-closed twins ---
+
+    def test_unlisted_model_does_not_alias(self, monkeypatch):
+        monkeypatch.setenv("JDOCMUNCH_FASTEMBED_MODEL", "BAAI/bge-small-en-v1.5")
+        monkeypatch.setenv("JDOCMUNCH_ST_MODEL", "BAAI/bge-small-en-v1.5")
+        assert prov.sidecar_identity("fastembed") == (
+            "fastembed", "BAAI/bge-small-en-v1.5", None,
+        )
+
+    def test_divergent_st_model_does_not_alias(self, monkeypatch):
+        """Two runtimes pointed at two models are two vector spaces, even
+        when the FastEmbed side is allow-listed."""
+        monkeypatch.setenv("JDOCMUNCH_ST_MODEL", "intfloat/e5-large-v2")
+        assert prov.sidecar_identity("fastembed")[0] == "fastembed"
+
+    def test_empty_model_does_not_alias(self, monkeypatch):
+        monkeypatch.setenv("JDOCMUNCH_FASTEMBED_MODEL", "")
+        monkeypatch.setenv("JDOCMUNCH_ST_MODEL", "")
+        assert prov.sidecar_identity("fastembed")[0] == "fastembed"
+
+    def test_allow_list_is_not_empty_and_holds_canonical_ids(self):
+        """A bare name here would never match a canonicalised lookup, so the
+        allow-list would silently never fire."""
+        assert prov._FASTEMBED_ST_EQUIVALENT_MODELS
+        for entry in prov._FASTEMBED_ST_EQUIVALENT_MODELS:
+            assert entry == prov._canonical_hub_model_id(entry)
+
+    def test_other_providers_are_unchanged(self):
+        for name in ("gemini", "openai", "sentence-transformers"):
+            model, dim = prov._provider_identity(name)
+            assert prov.sidecar_identity(name) == (name, model, dim)
+
+
+class TestAliasedHeaderActuallyLoads:
+    """End-to-end at the layer that would have lost the vectors."""
+
+    def _write_st_sidecar(self, tmp_path):
+        emb_cache.write(
+            str(tmp_path), "owner", "repo",
+            provider="sentence-transformers", model="all-MiniLM-L6-v2", dim=None,
+            entries=[("abc#pv1", [0.1, 0.2, 0.3])], embed_chars=1000,
+        )
+
+    def test_fastembed_reads_a_sentence_transformers_sidecar(self, tmp_path):
+        self._write_st_sidecar(tmp_path)
+        provider, model, dim = prov.sidecar_identity("fastembed")
+        loaded = emb_cache.load(
+            str(tmp_path), "owner", "repo",
+            provider=provider, model=model, dim=dim, embed_chars=1000,
+        )
+        assert loaded == {"abc#pv1": [0.1, 0.2, 0.3]}
+
+    def test_unlisted_model_gets_nothing_back(self, tmp_path, monkeypatch):
+        """The fail-closed half, and the one that matters: an unmeasured model
+        must MISS, forcing a re-embed rather than inheriting vectors it did
+        not produce."""
+        self._write_st_sidecar(tmp_path)
+        monkeypatch.setenv("JDOCMUNCH_FASTEMBED_MODEL", "BAAI/bge-small-en-v1.5")
+        provider, model, dim = prov.sidecar_identity("fastembed")
+        loaded = emb_cache.load(
+            str(tmp_path), "owner", "repo",
+            provider=provider, model=model, dim=dim, embed_chars=1000,
+        )
+        assert loaded == {}
+
+    def test_the_unconditional_alias_would_have_matched(self, tmp_path):
+        """Non-vacuity for the objection itself. Under a blanket rename the
+        bge lookup above returns the MiniLM vectors - the silent merge,
+        demonstrated rather than argued."""
+        self._write_st_sidecar(tmp_path)
+        loaded = emb_cache.load(
+            str(tmp_path), "owner", "repo",
+            provider="sentence-transformers",   # the unconditional normalization
+            model="all-MiniLM-L6-v2", dim=None, embed_chars=1000,
+        )
+        assert loaded == {"abc#pv1": [0.1, 0.2, 0.3]}
+
+
+class TestWriterAndReaderAgree:
+    """jdoc#109: a reader that skips the alias reports a rotation on every
+    index for a corpus that never moved."""
+
+    def test_index_local_reads_the_alias(self):
+        import inspect
+        from jdocmunch_mcp.tools import index_local
+        src = inspect.getsource(index_local)
+        assert "_emb_provider.sidecar_identity" in src
+        assert "_emb_provider._provider_identity" not in src
+
+    def test_embed_sections_writes_the_alias(self):
+        import inspect
+        src = inspect.getsource(prov.embed_sections)
+        assert "sidecar_identity(" in src
+
+
+# ---------------------------------------------------------------------------
+# The sentence-transformers machinery must not fire for a provider that never
+# imports it
+# ---------------------------------------------------------------------------
+
+class TestNoSentenceTransformersMachinery:
+    def test_import_probe_is_not_run_for_fastembed(self, monkeypatch):
+        """On a machine where sentence-transformers is broken, probing it
+        would suppress a provider that works fine."""
+        monkeypatch.setenv("JDOCMUNCH_EMBEDDING_PROVIDER", "fastembed")
+
+        def _boom():
+            raise AssertionError("probed sentence-transformers for fastembed")
+
+        monkeypatch.setattr(prov, "_sentence_transformers_imports_cleanly", _boom)
+        monkeypatch.setitem(prov._PROVIDER_FACTORIES, "fastembed", lambda: object())
+        # Non-vacuity: the probe is also skipped when the embed worker is on,
+        # so assert we are actually on the fastembed path before concluding
+        # anything from the absence of an explosion.
+        assert prov.get_provider_name() == "fastembed"
+        assert prov._get_provider() is not None
+
+    def test_warmup_probe_is_not_run_for_fastembed(self, monkeypatch):
+        monkeypatch.setenv("JDOCMUNCH_EMBEDDING_PROVIDER", "fastembed")
+
+        def _boom():
+            raise AssertionError("probed sentence-transformers for fastembed")
+
+        monkeypatch.setattr(prov, "_sentence_transformers_imports_cleanly", _boom)
+        monkeypatch.setattr(prov, "_active_model_is_cached", lambda _n: False)
+        assert prov.warmup() == ""
+
+    def test_worker_is_not_used_for_fastembed(self, monkeypatch):
+        """onnxruntime is a different DLL set; jdoc#118's deadlock is an
+        argument about torch, not evidence about ONNX."""
+        monkeypatch.setattr(prov, "_embed_worker_enabled", lambda: True)
+        assert prov._PROVIDER_FACTORIES["fastembed"] is prov._FastEmbedProvider
+
+    def test_preload_gate_skips_fastembed(self, monkeypatch):
+        from jdocmunch_mcp import preload
+        monkeypatch.setenv("JDOCMUNCH_PRELOAD_EMBEDDINGS", "1")
+        monkeypatch.setenv("JDOCMUNCH_EMBEDDING_PROVIDER", "fastembed")
+        result = preload.preload_embedding_stack()
+        assert "absent" in result.get("sentence_transformers", "")
+
+
+# ---------------------------------------------------------------------------
+# jdoc#110: the cache probe must read FastEmbed's cache, not HuggingFace's
+# ---------------------------------------------------------------------------
+
+class TestCacheProbeIsProviderAware:
+    def test_warmup_dispatches_on_the_active_provider(self, monkeypatch):
+        seen = []
+        monkeypatch.setattr(
+            prov, "_st_model_is_cached", lambda m: seen.append(("st", m)) or True
+        )
+        monkeypatch.setattr(
+            prov, "_fastembed_model_is_cached", lambda m: seen.append(("fe", m)) or True
+        )
+        prov._active_model_is_cached("fastembed")
+        prov._active_model_is_cached("sentence-transformers")
+        assert [kind for kind, _ in seen] == ["fe", "st"]
+
+    def test_a_populated_hf_cache_is_not_evidence(self, tmp_path, monkeypatch):
+        """The defect a shared probe would have: torch has the model, ONNX
+        still has to download it, and warmup then blocks the MCP handshake on
+        that download - jdoc#110's outage, reported to the user as nothing but
+        'connection timed out'."""
+        hub = tmp_path / "hub"
+        snap = hub / "models--sentence-transformers--all-MiniLM-L6-v2" / "snapshots" / "abc"
+        snap.mkdir(parents=True)
+        (snap / "config.json").write_text("{}", encoding="utf-8")
+        monkeypatch.setenv("HF_HUB_CACHE", str(hub))
+        monkeypatch.setenv("FASTEMBED_CACHE_PATH", str(tmp_path / "empty-fastembed"))
+        model = "sentence-transformers/all-MiniLM-L6-v2"
+        # The control: the same tree DOES satisfy the sentence-transformers
+        # probe, so this is a difference between the two probes and not an
+        # empty fixture.
+        assert prov._st_model_is_cached(model) is True
+        assert prov._fastembed_model_is_cached(model) is False
+
+    def test_fastembed_cache_dir_is_read(self, tmp_path, monkeypatch):
+        root = tmp_path / "fe"
+        snap = root / "models--sentence-transformers--all-MiniLM-L6-v2" / "snapshots" / "abc"
+        snap.mkdir(parents=True)
+        (snap / "model.onnx").write_text("x", encoding="utf-8")
+        monkeypatch.setenv("FASTEMBED_CACHE_PATH", str(root))
+        assert prov._fastembed_model_is_cached(
+            "sentence-transformers/all-MiniLM-L6-v2"
+        ) is True
+
+    def test_flat_layout_is_read(self, tmp_path, monkeypatch):
+        root = tmp_path / "fe"
+        flat = root / "sentence-transformers_all-MiniLM-L6-v2"
+        flat.mkdir(parents=True)
+        (flat / "model.onnx").write_text("x", encoding="utf-8")
+        monkeypatch.setenv("FASTEMBED_CACHE_PATH", str(root))
+        assert prov._fastembed_model_is_cached(
+            "sentence-transformers/all-MiniLM-L6-v2"
+        ) is True
+
+    def test_bare_name_resolves_to_the_qualified_cache_key(self, tmp_path, monkeypatch):
+        """The jdoc#110 probe bug, not repeated: a bare name is not the cache
+        key, so probing only the literal string reports the default model
+        uncached on every machine that has it."""
+        root = tmp_path / "fe"
+        snap = root / "models--sentence-transformers--all-MiniLM-L6-v2" / "snapshots" / "abc"
+        snap.mkdir(parents=True)
+        (snap / "model.onnx").write_text("x", encoding="utf-8")
+        monkeypatch.setenv("FASTEMBED_CACHE_PATH", str(root))
+        assert prov._fastembed_model_is_cached("all-MiniLM-L6-v2") is True
+
+    def test_empty_model_fails_open(self):
+        assert prov._fastembed_model_is_cached("") is True
+
+    def test_missing_cache_root_is_not_cached(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("FASTEMBED_CACHE_PATH", str(tmp_path / "nope"))
+        assert prov._fastembed_model_is_cached(
+            "sentence-transformers/all-MiniLM-L6-v2"
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# The extra stays optional, and the download is disclosed
+# ---------------------------------------------------------------------------
+
+def test_fastembed_is_an_optional_extra_not_a_dependency():
+    import tomllib
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[1]
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    assert "fastembed" in data["project"]["optional-dependencies"]
+    for dep in data["project"]["dependencies"]:
+        assert "fastembed" not in dep
+        assert "onnxruntime" not in dep
+
+
+def test_readme_discloses_the_download():
+    """PyPI-quarantine standing rule: a new network behavior is README-disclosed
+    before it ships."""
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "README.md").read_text(encoding="utf-8").lower()
+    assert "fastembed" in text


### PR DESCRIPTION
Closes #126. Reported by @LuigiNicaPRO.

## The reported defect

`get_provider_name()` is a closed if-chain, so `JDOCMUNCH_EMBEDDING_PROVIDER=fastembed` fell through it to auto-detect and `_PROVIDER_FACTORIES` was unreachable for the name. A closed chain and a factory map are two lists that have to agree, and nothing asserted that they did.

## The part that changed shape in review

The reported remedy is to normalize the provider name after `_get_provider()` resolves, so the sidecar header keeps saying `sentence-transformers` and the existing vectors load instead of the corpus being re-embedded. Right goal — the problem is that the normalization is unconditional.

`cache.load` matches the header by exact equality on `(provider, model, dim)`, and `_provider_identity` returns `dim=None` for both offline providers, which the cache reads as a wildcard. There is nothing underneath a normalized provider name to catch a mismatch. `JDOCMUNCH_ST_MODEL` is user-settable, so a blanket rename writes `sentence-transformers` over vectors some other model produced, `cache.load` then **matches**, the two derivations merge into one sidecar, and search ranks across both. That's jdoc#111's shape, and it's worse than the re-embed it avoids: a full re-embed is expensive and observable, this is cheap and invisible.

So the alias is `_FASTEMBED_ST_EQUIVALENT_MODELS`, an explicit per-model allow-list. It fails closed on an unlisted model, on a `JDOCMUNCH_ST_MODEL` naming a different model, and on an empty model. A model earns a place on that list by being measured identical across the two runtimes; `check_embedding_drift` is the measurement, since a canary captured under one runtime and re-run under the other reports exactly that.

Two details that look like oversights and aren't. The alias writes the sentence-transformers **spelling** (`all-MiniLM-L6-v2` by default), not the canonical hub id, because the header is an exact string match against a file that already exists. And the dim stays `None` — every sentence-transformers sidecar ever written stores `None` there, so an active 384 would compare unequal and purge the file the alias exists to reuse.

New `sidecar_identity()` is the single place resolving the header triple. `index_local`'s rotation detector reads it too, or it reports a rotation on every index for a corpus that never moved (jdoc#109).

## The cache probe

`_st_model_is_cached()` probes the HuggingFace hub layout, and jdoc#110's warmup gate uses it to decide whether a model load would block the MCP handshake on a download. FastEmbed downloads into its own directory, so sharing the probe reports "cached" for a machine whose HF cache holds the model for torch while FastEmbed still has to fetch it. A populated HF cache is deliberately not taken as evidence: guessing "cached" is the harmful guess, guessing "not cached" costs a deferred load.

## Left alone on purpose

The sentence-transformers import probe and the embed worker don't fire for FastEmbed. Neither is about embeddings in general; both are about torch. onnxruntime loads a different DLL set, so jdoc#118's Windows loader deadlock is an argument here rather than evidence, and probing a package this provider never imports would suppress a working provider on a machine where sentence-transformers happens to be broken. If FastEmbed wedges the same way on Windows, the worker is the fix and the measurement comes first.

## Scope

- `fastembed` is an optional extra, never a runtime dependency.
- Auto-detect prefers FastEmbed when both offline providers are installed; `JDOCMUNCH_EMBEDDING_PROVIDER=sentence-transformers` is the way back.
- First-use model download is README-disclosed under "Background behavior, fully disclosed" before shipping, per the PyPI-quarantine rule.
- No tool, schema or `INDEX_VERSION` change.

## Verification

`tests/test_jdoc_126_fastembed_provider.py`, 42 tests, **41 fail against the pre-fix tree** (checked in a throwaway worktree at `2f34a80`). The single both-sides pass is the control that demonstrates the unconditional alias matching a sidecar it should not.

Suite **2646 passed / 6 skipped**. `ruff check src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br5Q4FCxdeBUBPYY8dbNMg
