### PR TITLE
fix(tests): pin both offline providers, and measure the #126 equivalence

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "jdocmunch",
   "displayName": "jDocMunch",
-  "version": "1.137.0",
+  "version": "1.137.1",
   "description": "Token-efficient MCP server for structured documentation retrieval via section-level indexing",
   "author": {
     "name": "J. Gravelle",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## [Unreleased]
 
+## [1.137.1] - 2026-08-28 - The equivalence is measured, and five tests were reading site-packages
+
+### The measurement behind 1.137.0's allow-list
+
+`sentence-transformers/all-MiniLM-L6-v2` is on the allow-list because it was
+measured, on 2026-08-28, with the tool the allow-list names for the purpose:
+`capture_canary` under sentence-transformers 2.5.0 / torch 2.5.1, then
+`check_drift` under fastembed 0.8.0 / onnxruntime 1.23.2 against that snapshot.
+
+Over the 16 canary strings, **max drift 6.0e-13** (min cosine
+0.9999999999993988) and **max absolute per-component delta 1.9e-07** on 384
+dims. That is float32 rounding, not a difference between models. The control
+that makes it a measurement of ONNX rather than of torch: after the FastEmbed
+pass, `sys.modules` held none of `torch`, `sentence_transformers` or
+`transformers`, and `onnxruntime` was loaded.
+
+End to end on a 32-section corpus indexed under sentence-transformers, then
+re-indexed with `incremental=False` under FastEmbed: **0 calls to the embedder,
+0 texts sent**, no `embedding_rotation` in the response, sidecar header
+unchanged at `sentence-transformers` / `all-MiniLM-L6-v2`, coverage 1.0. The
+fail-closed half was checked at the same entry point: with
+`JDOCMUNCH_FASTEMBED_MODEL=BAAI/bge-small-en-v1.5` the same store discloses
+`embedding_rotation ... full_re_embed` and re-embeds all 32 sections.
+
+⚠ One box, one version pair. The numbers say these two runtimes agree here;
+they are not a claim about every future release of either, which is why the
+allow-list is a list rather than a rule.
+
+### Fixed - five tests pinned half the offline fallback
+
+Adding a second offline provider to auto-detect broke five existing tests that
+stub `_sentence_transformers_available` and not `_fastembed_available` - they
+pinned half the fallback and read the machine for the other half. Invisible on
+CI, which installs neither. A new AST ratchet fails the build when a test pins
+one probe and not the other, scoped to functions that actually call
+`get_provider_name`/`should_embed` so the jdoc#118 probe tests are not false
+positives, with an exemption list carrying reasons. Proven against the defect
+put back and against three shapes it must not flag.
+
+
 ## [1.137.0] - 2026-08-28 - FastEmbed, and an alias narrow enough to be safe
 
 Reported by @LuigiNicaPRO ([#126](https://github.com/jgravelle/jdocmunch-mcp/issues/126)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,45 @@
 # jdocmunch-mcp
 
-**Version:** 1.137.0 |
+**Version:** 1.137.1 |
 **Tests:** `PYTHONPATH=src pytest tests/ -q`
+
+## v1.137.1 — the equivalence is MEASURED, and five tests were reading site-packages
+
+⚠⚠ **v1.137.0 shipped the allow-list with the equivalence ASSERTED, not
+measured — this closes that.** `capture_canary` under sentence-transformers
+2.5.0 / torch 2.5.1, then `check_drift` under fastembed 0.8.0 / onnxruntime
+1.23.2 against that snapshot: over 16 canary strings **max drift 6.0e-13** (min
+cosine 0.9999999999993988), **max per-component delta 1.9e-07** on 384 dims.
+Float32 rounding, not a model difference. ⚠ **The control is what makes it a
+measurement of ONNX rather than of torch**: after the pass, `sys.modules` held
+none of torch / sentence_transformers / transformers, and onnxruntime was
+loaded. Without that check a silent fallback to the ST provider would produce
+a perfect score and mean nothing.
+
+End to end on a 32-section corpus indexed under ST, re-indexed
+`incremental=False` under FastEmbed: **0 embedder calls, 0 texts**, no
+`embedding_rotation`, header unchanged, coverage 1.0. Fail-closed half at the
+same entry point: `JDOCMUNCH_FASTEMBED_MODEL=BAAI/bge-small-en-v1.5` discloses
+`full_re_embed` and re-embeds all 32. ⚠ One box, one version pair — **the
+allow-list is a LIST rather than a rule for exactly this reason.**
+
+⚠⚠ **Installing fastembed on this box turned FIVE existing tests red, and CI
+could not see it because CI installs neither offline provider.** They stub
+`_sentence_transformers_available` and not `_fastembed_available`, so they
+pinned half the fallback and read the developer's site-packages for the other
+half ([[feedback_an_assumption_about_the_machine_is_not_a_fixture]]).
+**Adding a second member to an auto-detect chain invalidates every test that
+pinned the first one.** New AST ratchet in
+`tests/test_jdoc_126_fastembed_provider.py` fails when a test pins one probe
+and not the other. ⚠ Scoped to functions that actually call
+`get_provider_name`/`should_embed` — without that it flags every jdoc#118
+import-probe test, which never reaches the fallback, and **a guard with false
+positives is one nobody believes**. Exemptions carry reasons; proven against
+the defect put back AND against three shapes it must not flag.
+
+⚠ The measurement is a SEPARATE release, not an edit to 1.137.0's entry —
+that artifact is on PyPI and its CHANGELOG is what it shipped with
+(the v1.134.1 provenance lesson).
 
 ## v1.137.0 — #126: the alias keys on the MODEL, because the sidecar has no dim backstop
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jdocmunch-mcp"
-version = "1.137.0"
+version = "1.137.1"
 description = "Token-efficient MCP server for structured documentation retrieval via section-level indexing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.jgravelle/jdocmunch-mcp",
   "title": "jDocmunch MCP",
   "description": "Section-level doc search for .md, .rst, .adoc, .ipynb, .html, .yaml, .json, and OpenAPI specs.",
-  "version": "1.137.0",
+  "version": "1.137.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "jdocmunch-mcp",
-      "version": "1.137.0",
+      "version": "1.137.1",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_jdoc_126_fastembed_provider.py
+++ b/tests/test_jdoc_126_fastembed_provider.py
@@ -415,3 +415,108 @@ def test_readme_discloses_the_download():
     root = Path(__file__).resolve().parents[1]
     text = (root / "README.md").read_text(encoding="utf-8").lower()
     assert "fastembed" in text
+
+
+# ---------------------------------------------------------------------------
+# Ratchet: a test that pins one offline provider must pin the other
+# ---------------------------------------------------------------------------
+
+# Tests that stub exactly one of the two availability probes ON PURPOSE, with
+# the reason. Add an entry with its reason; never loosen the rule.
+_SINGLE_PROBE_EXEMPT = {
+    # Sets JDOCMUNCH_EMBEDDING_PROVIDER explicitly, so auto-detect's offline
+    # fallback is unreachable and the unpinned probe cannot change the result.
+    "test_incomplete_openai_compatible_env_does_not_fall_through":
+        "explicit provider set; the fallback branch is never reached",
+    "test_fastembed_does_not_preempt_a_named_cloud_provider":
+        "explicit provider set; the fallback branch is never reached",
+    # Pins both, but in a loop the AST scan cannot follow.
+    "test_offline_provider_still_wins_when_available":
+        "pins both in a loop, then re-stubs the one under test",
+}
+
+_PROBES = ("_sentence_transformers_available", "_fastembed_available")
+
+# The scan only flags a function that actually asks auto-detect a question.
+# Without this it flags every test of the sentence-transformers import probe
+# (jdoc#118), which never reaches the fallback and for which the FastEmbed
+# probe is irrelevant. A guard with false positives is one nobody believes,
+# and a ratchet nobody believes collects exemptions.
+_AUTODETECT_CALLERS = ("get_provider_name", "should_embed")
+
+
+def _stubbed_probes(node):
+    """Availability probes patched anywhere inside one function body."""
+    import ast
+    found = set()
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Call):
+            continue
+        for arg in sub.args:
+            if isinstance(arg, ast.Constant) and arg.value in _PROBES:
+                found.add(arg.value)
+    return found
+
+
+def _single_probe_offenders(paths):
+    import ast
+    offenders = []
+    for path in paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            stubbed = _stubbed_probes(node)
+            if len(stubbed) != 1 or node.name in _SINGLE_PROBE_EXEMPT:
+                continue
+            if not any(c in ast.dump(node) for c in _AUTODETECT_CALLERS):
+                continue
+            offenders.append(f"{path.name}::{node.name} pins only {stubbed.pop()}")
+    return offenders
+
+
+def test_no_test_pins_only_one_offline_provider():
+    """jdoc#126 added a SECOND offline provider to auto-detect, so a test that
+    stubs one probe and not the other reads the developer's site-packages for
+    the other half. Five tests did, and every one of them was green on CI and
+    red on a box with fastembed installed
+    ([[feedback_an_assumption_about_the_machine_is_not_a_fixture]])."""
+    from pathlib import Path
+    tests_dir = Path(__file__).resolve().parent
+    offenders = _single_probe_offenders(sorted(tests_dir.glob("test_*.py")))
+    assert not offenders, "tests pinning only one offline provider:\n" + "\n".join(offenders)
+
+
+def test_the_ratchet_is_not_vacuous(tmp_path):
+    """Run the detector against the defect PUT BACK, and against a correct
+    shape it must not flag. A green ratchet and an absent ratchet look
+    identical when the tree is already clean."""
+    bad = tmp_path / "test_bad.py"
+    bad.write_text(
+        "def test_x(monkeypatch):\n"
+        "    monkeypatch.setattr(prov, '_sentence_transformers_available', lambda: False)\n"
+        "    assert prov.get_provider_name() is None\n",
+        encoding="utf-8",
+    )
+    assert _single_probe_offenders([bad]), "detector missed a single-probe stub"
+
+    # Positive controls: three shapes it must NOT flag.
+    good = tmp_path / "test_good.py"
+    good.write_text(
+        # both probes pinned
+        "def test_y(monkeypatch):\n"
+        "    monkeypatch.setattr(prov, '_sentence_transformers_available', lambda: False)\n"
+        "    monkeypatch.setattr(prov, '_fastembed_available', lambda: False)\n"
+        "    assert prov.get_provider_name() is None\n"
+        "\n"
+        # one pinned, but never asks auto-detect anything (the jdoc#118 shape)
+        "def test_z(monkeypatch):\n"
+        "    monkeypatch.setattr(prov, '_sentence_transformers_available', lambda: True)\n"
+        "    assert prov._sentence_transformers_imports_cleanly() is True\n"
+        "\n"
+        # neither pinned
+        "def test_w():\n"
+        "    assert prov.get_provider_name() in (None, 'fastembed')\n",
+        encoding="utf-8",
+    )
+    assert not _single_probe_offenders([good]), "detector flagged a correct shape"

--- a/tests/test_openai_compatible_embeddings.py
+++ b/tests/test_openai_compatible_embeddings.py
@@ -79,6 +79,9 @@ def test_openai_compatible_is_not_auto_detected(monkeypatch):
     _clear_embedding_env(monkeypatch)
     monkeypatch.setenv("JDOCMUNCH_OPENAI_COMPAT_URL", "http://localhost:11434/v1")
     monkeypatch.setenv("JDOCMUNCH_OPENAI_COMPAT_MODEL", "nomic-embed-text")
+    # jdoc#126: both offline providers, or the assertion reads the developer's
+    # site-packages for whichever half is left unpinned.
+    monkeypatch.setattr(emb_provider, "_fastembed_available", lambda: False)
     monkeypatch.setattr(emb_provider, "_sentence_transformers_available", lambda: False)
 
     assert emb_provider.get_provider_name() is None

--- a/tests/test_paid_embeddings_optin.py
+++ b/tests/test_paid_embeddings_optin.py
@@ -49,9 +49,17 @@ def clean_env(monkeypatch):
 def no_local(monkeypatch):
     """Force the offline fallback unavailable so the cloud decision is visible.
 
-    With sentence-transformers installed the guard falls through to it, which is
+    With an offline provider installed the guard falls through to it, which is
     the desired product behaviour but hides which branch was taken.
+
+    jdoc#126: there are now TWO offline providers, and pinning one of them is
+    pinning half the fallback. Stubbing only sentence-transformers left this
+    fixture reading the developer's site-packages for the other half - green on
+    CI, red on any box with fastembed installed
+    ([[feedback_an_assumption_about_the_machine_is_not_a_fixture]]). Any test
+    reasoning about the offline fallback has to pin both.
     """
+    monkeypatch.setattr(provider, "_fastembed_available", lambda: False)
     monkeypatch.setattr(provider, "_sentence_transformers_available", lambda: False)
 
 
@@ -95,12 +103,27 @@ def test_should_embed_auto_follows_the_guard(clean_env, no_local):
     assert provider.should_embed("auto") is True
 
 
-def test_offline_provider_still_wins_when_available(clean_env, monkeypatch):
+@pytest.mark.parametrize(
+    "available,expected",
+    [
+        ("_sentence_transformers_available", "sentence-transformers"),
+        ("_fastembed_available", "fastembed"),
+    ],
+)
+def test_offline_provider_still_wins_when_available(
+    clean_env, monkeypatch, available, expected
+):
     """Suppressing paid cloud must not disable embedding outright when a local
-    provider exists. Semantic search keeps working, on-machine."""
-    monkeypatch.setattr(provider, "_sentence_transformers_available", lambda: True)
+    provider exists. Semantic search keeps working, on-machine.
+
+    jdoc#126: parametrized over both offline providers, and each case pins the
+    OTHER one off - otherwise the assertion is about which happens to be
+    installed on the machine running it."""
+    for name in ("_sentence_transformers_available", "_fastembed_available"):
+        monkeypatch.setattr(provider, name, lambda: False)
+    monkeypatch.setattr(provider, available, lambda: True)
     clean_env.setenv("OPENAI_API_KEY", "sk-not-a-real-key")
-    assert provider.get_provider_name() == "sentence-transformers"
+    assert provider.get_provider_name() == expected
 
 
 def test_suppression_is_logged_not_silent(clean_env, no_local, caplog):


### PR DESCRIPTION
Follow-up to #127, both items found by actually installing `fastembed` on the dev box rather than reasoning about it.

## 1. The equivalence is measured now

v1.137.0 shipped the allow-list with the vector equivalence **asserted**. Measured with the tool the allow-list names for the purpose — `capture_canary` under sentence-transformers 2.5.0 / torch 2.5.1, then `check_drift` under fastembed 0.8.0 / onnxruntime 1.23.2 against that snapshot:

| | |
|---|---|
| canary strings | 16, 384 dims |
| max drift (`1 - cos`) | **6.0e-13** |
| min cosine | 0.9999999999993988 |
| max abs per-component delta | **1.9e-07** |

Float32 rounding, not a difference between models.

The control matters more than the number: after the FastEmbed pass, `sys.modules` held none of `torch`, `sentence_transformers` or `transformers`, and `onnxruntime` was loaded. Without that, a silent fallback to the sentence-transformers provider would score perfectly and mean nothing.

End to end on a 32-section corpus indexed under sentence-transformers, then re-indexed with `incremental=False` under FastEmbed: **0 calls to the embedder, 0 texts sent**, no `embedding_rotation`, header unchanged, coverage 1.0. Fail-closed half at the same entry point — `JDOCMUNCH_FASTEMBED_MODEL=BAAI/bge-small-en-v1.5` against the same store discloses `full_re_embed` and re-embeds all 32 sections.

One box, one version pair. The numbers say these two runtimes agree here; they aren't a claim about every future release of either, which is why the allow-list is a list and not a rule.

## 2. Five tests were reading the developer's site-packages

Adding a second offline provider to auto-detect turned five existing tests red on any machine with `fastembed` installed. They stub `_sentence_transformers_available` and not `_fastembed_available` — half the fallback pinned, the other half read off the machine. CI installs neither provider, so CI could not see it, and neither could I until the measurement above required the install.

**Adding a member to an auto-detect chain invalidates every test that pinned the previous one.** A new AST ratchet fails the build when a test pins one probe and not the other. It's scoped to functions that actually call `get_provider_name`/`should_embed`, because without that scope it flags every jdoc#118 import-probe test — those never reach the fallback, and a guard with false positives is one nobody believes. Exemptions carry reasons. The detector is proven against the defect put back and against three shapes it must not flag.

## Note on versioning

The measurement is a **separate 1.137.1 entry**, not an edit to 1.137.0's. That artifact is on PyPI and its CHANGELOG is what it shipped with — the v1.134.1 provenance lesson.

Suite **2649 passed / 6 skipped** with fastembed installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br5Q4FCxdeBUBPYY8dbNMg
